### PR TITLE
Use npm trusted publishing (OIDC) for CI publish

### DIFF
--- a/.github/workflows/publish-drizzle-audit.yml
+++ b/.github/workflows/publish-drizzle-audit.yml
@@ -37,6 +37,9 @@ jobs:
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -54,10 +57,8 @@ jobs:
         working-directory: packages/drizzle_audit
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance --access public
         working-directory: packages/drizzle_audit
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 
   publish-gpr:
     needs: test

--- a/.github/workflows/publish-drizzle-repositories.yml
+++ b/.github/workflows/publish-drizzle-repositories.yml
@@ -18,6 +18,9 @@ jobs:
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -35,10 +38,8 @@ jobs:
         working-directory: packages/drizzle_repositories
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance --access public
         working-directory: packages/drizzle_repositories
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 
   publish-gpr:
     needs: test

--- a/packages/drizzle_audit/package.json
+++ b/packages/drizzle_audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-audit",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Lightweight audit logging for Drizzle ORM using database triggers (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/drizzle_repositories/package.json
+++ b/packages/drizzle_repositories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-repositories",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Generic repository layer for Drizzle ORM with audit logging (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",


### PR DESCRIPTION
## Summary
- Switch npm publish from token auth (`NPMJS_TOKEN`) to trusted publishing via GitHub Actions OIDC
- Add `id-token: write` permission and `--provenance` flag to publish-npm jobs
- No more npm token/OTP needed for CI publishes

## Setup required
Configure trusted publishers on npmjs.com for each package:
- `@willyim/drizzle-audit` → `publish-drizzle-audit.yml`
- `@willyim/drizzle-repositories` → `publish-drizzle-repositories.yml`