### PR TITLE
Drop GPR publish, use npm-only with trusted publishing

### DIFF
--- a/.github/workflows/publish-drizzle-audit.yml
+++ b/.github/workflows/publish-drizzle-audit.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   test:
@@ -59,37 +58,3 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public
         working-directory: packages/drizzle_audit
-
-  publish-gpr:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@willyim"
-
-      - name: Override root .npmrc
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
-          echo "@willyim:registry=https://npm.pkg.github.com" >> .npmrc
-
-      - name: Install dependencies
-        run: npm install
-        working-directory: packages/drizzle_audit
-
-      - name: Build
-        run: npm run build
-        working-directory: packages/drizzle_audit
-
-      - name: Publish to GitHub Packages
-        run: npm publish --registry https://npm.pkg.github.com
-        working-directory: packages/drizzle_audit
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-drizzle-repositories.yml
+++ b/.github/workflows/publish-drizzle-repositories.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   test:
@@ -40,37 +39,3 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public
         working-directory: packages/drizzle_repositories
-
-  publish-gpr:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@willyim"
-
-      - name: Override root .npmrc
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
-          echo "@willyim:registry=https://npm.pkg.github.com" >> .npmrc
-
-      - name: Install dependencies
-        run: npm install
-        working-directory: packages/drizzle_repositories
-
-      - name: Build
-        run: npm run build
-        working-directory: packages/drizzle_repositories
-
-      - name: Publish to GitHub Packages
-        run: npm publish --registry https://npm.pkg.github.com
-        working-directory: packages/drizzle_repositories
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/drizzle_audit/package.json
+++ b/packages/drizzle_audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-audit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Lightweight audit logging for Drizzle ORM using database triggers (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/drizzle_repositories/package.json
+++ b/packages/drizzle_repositories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-repositories",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Generic repository layer for Drizzle ORM with audit logging (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",


### PR DESCRIPTION
## Summary
- Remove `publish-gpr` jobs (GPR requires scope to match repo owner, can't publish `@willyim` from `wovalle` repo)
- Bump drizzle-audit to 0.2.1 and drizzle-repositories to 0.1.1 to trigger publish

## Test plan
- [ ] Verify publish-npm jobs succeed after merge