### PR TITLE
drizzle-audit: add computeDiff utility

### DIFF
--- a/packages/drizzle_audit/package.json
+++ b/packages/drizzle_audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-audit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Lightweight audit logging for Drizzle ORM using database triggers (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/drizzle_audit/src/compute-diff.ts
+++ b/packages/drizzle_audit/src/compute-diff.ts
@@ -1,0 +1,53 @@
+export type DiffEntry = {
+  field: string;
+  old: unknown;
+  new: unknown;
+};
+
+export type DiffResult = {
+  operation: string;
+  changes: DiffEntry[];
+};
+
+export type ComputeDiffOptions = {
+  /** Fields to exclude from the diff (default: ["updated_at", "created_at"]) */
+  ignoreFields?: string[];
+};
+
+const DEFAULT_IGNORE = ["updated_at", "created_at"];
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function computeDiff(
+  operation: string,
+  oldData: Record<string, unknown> | null,
+  newData: Record<string, unknown> | null,
+  options?: ComputeDiffOptions,
+): DiffResult {
+  const ignore = options?.ignoreFields ?? DEFAULT_IGNORE;
+
+  if (oldData === null && newData === null) {
+    return { operation, changes: [] };
+  }
+
+  const allKeys = Array.from(
+    new Set([...Object.keys(oldData ?? {}), ...Object.keys(newData ?? {})]),
+  )
+    .filter((k) => !ignore.includes(k))
+    .sort();
+
+  const changes: DiffEntry[] = [];
+
+  for (const field of allKeys) {
+    const oldVal = oldData?.[field] ?? null;
+    const newVal = newData?.[field] ?? null;
+
+    if (!deepEqual(oldVal, newVal)) {
+      changes.push({ field, old: oldVal, new: newVal });
+    }
+  }
+
+  return { operation, changes };
+}

--- a/packages/drizzle_audit/src/index.ts
+++ b/packages/drizzle_audit/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./postgres/index.js"
 export * from "./d1/index.js"
 export * from "./d1-runtime/index.js"
+export * from "./compute-diff.js"

--- a/packages/drizzle_audit/test/compute-diff.test.ts
+++ b/packages/drizzle_audit/test/compute-diff.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { computeDiff } from "../src/compute-diff.js"
+
+test("UPDATE — only changed fields are emitted", () => {
+  const result = computeDiff(
+    "UPDATE",
+    { name: "Juan", phone: "809", status: "current" },
+    { name: "Juan Carlos", phone: "809", status: "current" },
+  )
+  assert.deepEqual(result, {
+    operation: "UPDATE",
+    changes: [{ field: "name", old: "Juan", new: "Juan Carlos" }],
+  })
+})
+
+test("UPDATE — ignores updated_at by default", () => {
+  const result = computeDiff(
+    "UPDATE",
+    { name: "A", updated_at: "2026-01-01" },
+    { name: "B", updated_at: "2026-04-15" },
+  )
+  assert.deepEqual(result, {
+    operation: "UPDATE",
+    changes: [{ field: "name", old: "A", new: "B" }],
+  })
+})
+
+test("UPDATE — ignores created_at by default", () => {
+  const result = computeDiff(
+    "UPDATE",
+    { name: "A", created_at: "2026-01-01" },
+    { name: "A", created_at: "2026-04-15" },
+  )
+  assert.deepEqual(result, { operation: "UPDATE", changes: [] })
+})
+
+test("INSERT — all fields with old: null", () => {
+  const result = computeDiff("INSERT", null, { name: "María", phone: "809" })
+  assert.deepEqual(result, {
+    operation: "INSERT",
+    changes: [
+      { field: "name", old: null, new: "María" },
+      { field: "phone", old: null, new: "809" },
+    ],
+  })
+})
+
+test("DELETE — all fields with new: null", () => {
+  const result = computeDiff("DELETE", { name: "Pedro", phone: "809" }, null)
+  assert.deepEqual(result, {
+    operation: "DELETE",
+    changes: [
+      { field: "name", old: "Pedro", new: null },
+      { field: "phone", old: "809", new: null },
+    ],
+  })
+})
+
+test("custom ignoreFields", () => {
+  const result = computeDiff("UPDATE", { a: 1, b: 2 }, { a: 1, b: 3 }, { ignoreFields: ["b"] })
+  assert.deepEqual(result, { operation: "UPDATE", changes: [] })
+})
+
+test("deep equality for nested objects", () => {
+  const result = computeDiff(
+    "UPDATE",
+    { payload: { x: 1 } },
+    { payload: { x: 2 } },
+  )
+  assert.deepEqual(result, {
+    operation: "UPDATE",
+    changes: [{ field: "payload", old: { x: 1 }, new: { x: 2 } }],
+  })
+})
+
+test("both null — returns empty changes", () => {
+  const result = computeDiff("UPDATE", null, null)
+  assert.deepEqual(result, { operation: "UPDATE", changes: [] })
+})
+
+test("changes are sorted alphabetically by field", () => {
+  const result = computeDiff(
+    "UPDATE",
+    { zebra: 1, apple: 2, mango: 3 },
+    { zebra: 2, apple: 3, mango: 4 },
+  )
+  assert.deepEqual(
+    result.changes.map((c) => c.field),
+    ["apple", "mango", "zebra"],
+  )
+})


### PR DESCRIPTION
Adds a `computeDiff` function to `@willyim/drizzle-audit` for producing field-by-field diffs from the `old_data`/`new_data` objects captured by audit triggers. The function is framework-agnostic (no Drizzle dependency) and supports INSERT, UPDATE, and DELETE operations with deep equality comparison for nested objects. Fields are returned sorted alphabetically and `updated_at`/`created_at` are excluded by default. Includes 9 unit tests covering all documented behaviors.