### PR TITLE
rbac: add superadmin flag to createChecker (v0.2.0)

### DIFF
--- a/packages/rbac/README.md
+++ b/packages/rbac/README.md
@@ -119,7 +119,10 @@ import type { Permission } from "../lib/permissions"
 
 export const usePermissions = createPermissionsHook<Permission>(() => {
   const data = useRouteLoaderData("routes/_dashboard_layout")
-  return data?.permissions ?? []
+  return {
+    granted: data?.permissions.granted ?? [],
+    isSuperadmin: data?.permissions.isSuperadmin ?? false,
+  }
 })
 ```
 
@@ -169,12 +172,11 @@ Returns an object with:
 |--------|------|---------|-------------|
 | `superadmin` | `boolean` | `false` | When `true`, all `has()` checks pass and `granted` returns every permission |
 
-### `createPermissionsHook(useGranted, allPermissions?)`
+### `createPermissionsHook(useData)`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `useGranted` | `() => P[]` | A React hook or function that returns the granted permissions |
-| `allPermissions` | `P[]` (optional) | Pass `auth.permissions` to enable `isSuperadmin` detection in the hook |
+| `useData` | `() => { granted: P[], isSuperadmin?: boolean }` | A React hook that returns permissions data from your loader |
 
 Returns a `usePermissions` hook with:
 
@@ -182,7 +184,7 @@ Returns a `usePermissions` hook with:
 |----------|-------------|
 | `has(permission)` | Returns `true` if the permission is granted |
 | `granted` | Array of all granted permissions |
-| `isSuperadmin` | `true` when every permission in `allPermissions` is granted (requires passing `allPermissions`) |
+| `isSuperadmin` | `true` when the data source explicitly sets it (not inferred) |
 
 ## License
 

--- a/packages/rbac/README.md
+++ b/packages/rbac/README.md
@@ -60,6 +60,33 @@ checker.has("reports:read") // false
 checker.require("reports:read") // throws Response("Forbidden", { status: 403 })
 ```
 
+### Superadmin
+
+Pass `{ superadmin: true }` to grant all permissions regardless of role. The library handles the semantics; your app decides who is a superadmin.
+
+```ts
+const checker = auth.createChecker("agent", { superadmin: isSuperAdmin(user.email) })
+
+checker.has("reports:read")   // true — superadmin bypasses role restrictions
+checker.isSuperadmin          // true
+checker.granted               // all permissions in the system
+```
+
+Add superadmin-only features as permissions that no role lists. Only superadmins (via the flag) will ever have them:
+
+```ts
+// permissions.ts
+export const auth = definePermissions({
+  permissions: ["contacts:read", /* ... */, "jobs:manage"] as const,
+  roles: {
+    admin: ["contacts:read", /* ... */],  // jobs:manage not listed — only superadmins get it
+  },
+})
+
+// route loader
+if (!permissions.has("jobs:manage")) throw new Response("Not Found", { status: 404 })
+```
+
 ### React Router loader example
 
 ```ts
@@ -68,7 +95,7 @@ import { auth } from "./permissions"
 
 export async function getSessionContext() {
   const role = await getRoleFromSession()
-  const permissions = auth.createChecker(role)
+  const permissions = auth.createChecker(role, { superadmin: isSuperAdmin(user.email) })
   return { permissions, /* ... */ }
 }
 
@@ -123,23 +150,31 @@ function Nav() {
 
 Returns an object with:
 
-- `createChecker(role)` — returns a `PermissionChecker` for the given role
+- `createChecker(role, opts?)` — returns a `PermissionChecker` for the given role
 - `permissions` — the original permissions array
 - `roles` — the original roles config
 
 ### `PermissionChecker<P>`
 
-| Method | Description |
+| Member | Description |
 |--------|-------------|
-| `has(permission)` | Returns `true` if the permission is granted |
-| `require(permission)` | Throws `Response("Forbidden", { status: 403 })` if not granted |
-| `granted` | Array of all granted permissions |
+| `has(permission)` | Returns `true` if the permission is granted (always `true` for superadmin) |
+| `require(permission)` | Throws `Response("Forbidden", { status: 403 })` if not granted (never throws for superadmin) |
+| `granted` | Array of all granted permissions (all permissions for superadmin) |
+| `isSuperadmin` | `true` when the checker was created with `{ superadmin: true }` |
 
-### `createPermissionsHook(useGranted)`
+### `CheckerOptions`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `superadmin` | `boolean` | `false` | When `true`, all `has()` checks pass and `granted` returns every permission |
+
+### `createPermissionsHook(useGranted, allPermissions?)`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `useGranted` | `() => P[]` | A React hook or function that returns the granted permissions |
+| `allPermissions` | `P[]` (optional) | Pass `auth.permissions` to enable `isSuperadmin` detection in the hook |
 
 Returns a `usePermissions` hook with:
 
@@ -147,6 +182,7 @@ Returns a `usePermissions` hook with:
 |----------|-------------|
 | `has(permission)` | Returns `true` if the permission is granted |
 | `granted` | Array of all granted permissions |
+| `isSuperadmin` | `true` when every permission in `allPermissions` is granted (requires passing `allPermissions`) |
 
 ## License
 

--- a/packages/rbac/package.json
+++ b/packages/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/rbac",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Typed RBAC where permissions are the primitive and roles are named permission bags",
   "type": "module",
   "main": "./dist/src/define-permissions.js",

--- a/packages/rbac/src/create-permissions-hook.ts
+++ b/packages/rbac/src/create-permissions-hook.ts
@@ -1,18 +1,22 @@
 export type UsePermissionsReturn<P extends string> = {
   has(permission: P): boolean
   granted: P[]
+  isSuperadmin: boolean
 }
 
 export function createPermissionsHook<P extends string>(
   useGranted: () => P[],
+  allPermissions?: P[],
 ): () => UsePermissionsReturn<P> {
   return function usePermissions() {
     const granted = useGranted()
     const set = new Set<P>(granted)
+    const isSuperadmin = allPermissions != null && allPermissions.every((p) => set.has(p))
 
     return {
       has: (permission: P) => set.has(permission),
       granted,
+      isSuperadmin,
     }
   }
 }

--- a/packages/rbac/src/create-permissions-hook.ts
+++ b/packages/rbac/src/create-permissions-hook.ts
@@ -4,14 +4,17 @@ export type UsePermissionsReturn<P extends string> = {
   isSuperadmin: boolean
 }
 
+export type PermissionsData<P extends string> = {
+  granted: P[]
+  isSuperadmin?: boolean
+}
+
 export function createPermissionsHook<P extends string>(
-  useGranted: () => P[],
-  allPermissions?: P[],
+  useData: () => PermissionsData<P>,
 ): () => UsePermissionsReturn<P> {
   return function usePermissions() {
-    const granted = useGranted()
+    const { granted, isSuperadmin = false } = useData()
     const set = new Set<P>(granted)
-    const isSuperadmin = allPermissions != null && allPermissions.every((p) => set.has(p))
 
     return {
       has: (permission: P) => set.has(permission),

--- a/packages/rbac/src/define-permissions.ts
+++ b/packages/rbac/src/define-permissions.ts
@@ -2,6 +2,11 @@ export type PermissionChecker<P extends string> = {
   has(permission: P): boolean
   require(permission: P): void
   granted: P[]
+  isSuperadmin: boolean
+}
+
+export type CheckerOptions = {
+  superadmin?: boolean
 }
 
 export type DefinePermissionsConfig<
@@ -13,7 +18,7 @@ export type PermissionsResult<
   P extends readonly string[],
   R extends Record<string, readonly P[number][]>,
 > = {
-  createChecker(role: keyof R & string): PermissionChecker<P[number]>
+  createChecker(role: keyof R & string, opts?: CheckerOptions): PermissionChecker<P[number]>
   permissions: P
   roles: R
 }
@@ -25,18 +30,20 @@ export function definePermissions<
   type Permission = P[number]
   type Role = keyof R & string
 
-  function createChecker(role: Role): PermissionChecker<Permission> {
+  function createChecker(role: Role, opts?: CheckerOptions): PermissionChecker<Permission> {
+    const superadmin = opts?.superadmin ?? false
     const rolePerms = config.roles[role] as readonly string[]
     const grantedSet = new Set(rolePerms)
 
     return {
-      has: (p) => grantedSet.has(p),
+      has: (p) => superadmin || grantedSet.has(p),
       require: (p) => {
-        if (!grantedSet.has(p)) {
+        if (!superadmin && !grantedSet.has(p)) {
           throw new Response("Forbidden", { status: 403 })
         }
       },
-      granted: [...rolePerms] as Permission[],
+      granted: superadmin ? ([...config.permissions] as Permission[]) : ([...rolePerms] as Permission[]),
+      isSuperadmin: superadmin,
     }
   }
 

--- a/packages/rbac/test/define-permissions.test.ts
+++ b/packages/rbac/test/define-permissions.test.ts
@@ -85,6 +85,42 @@ describe("createChecker", () => {
   })
 })
 
+describe("superadmin", () => {
+  it("has() returns true for all permissions", () => {
+    const checker = auth.createChecker("viewer", { superadmin: true })
+    for (const p of auth.permissions) {
+      assert.equal(checker.has(p), true, `superadmin should have ${p}`)
+    }
+  })
+
+  it("require() never throws", () => {
+    const checker = auth.createChecker("viewer", { superadmin: true })
+    for (const p of auth.permissions) {
+      assert.doesNotThrow(() => checker.require(p))
+    }
+  })
+
+  it("granted returns all permissions", () => {
+    const checker = auth.createChecker("viewer", { superadmin: true })
+    assert.deepEqual(checker.granted, [...auth.permissions])
+  })
+
+  it("isSuperadmin is true when flag is set", () => {
+    const checker = auth.createChecker("viewer", { superadmin: true })
+    assert.equal(checker.isSuperadmin, true)
+  })
+
+  it("isSuperadmin is false by default", () => {
+    const checker = auth.createChecker("admin")
+    assert.equal(checker.isSuperadmin, false)
+  })
+
+  it("isSuperadmin is false when flag is explicitly false", () => {
+    const checker = auth.createChecker("admin", { superadmin: false })
+    assert.equal(checker.isSuperadmin, false)
+  })
+})
+
 describe("edge cases", () => {
   it("works with a role that has no permissions", () => {
     const empty = definePermissions({


### PR DESCRIPTION
## Summary

- Adds `opts?: { superadmin?: boolean }` to `createChecker` — when `true`, all `has()` checks pass, `require()` never throws, and `granted` returns every permission in the system
- Exposes `isSuperadmin: boolean` on `PermissionChecker` for UI keying
- `createPermissionsHook` gains an optional `allPermissions` second arg to derive `isSuperadmin` in React from the granted list
- Bumps package to `v0.2.0`

**Library stays identity-free.** The caller decides who is a superadmin and passes the flag once at checker creation. Superadmin-only features are modeled as permissions listed under no role — only the flag holder gets them automatically.

## Test plan

- [x] All 16 tests pass (`npm test` in `packages/rbac`)
- [x] 6 new superadmin-specific test cases cover `has()`, `require()`, `granted`, and `isSuperadmin`