### PR TITLE
www: fix SSR build (dedupe drizzle-orm) broken by better-auth 1.6 bump

### DIFF
--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -15,4 +15,11 @@ export default defineConfig({
     tsconfigPaths(),
     contentCollections(),
   ],
+  resolve: {
+    // better-auth's drizzle adapter is hoisted to the repo root while drizzle-orm
+    // lives in this app's node_modules; without deduping, Vite can't resolve the
+    // adapter's optional drizzle-orm peer and the SSR build fails to bundle
+    // better-auth (e.g. "BetterAuthError is not exported").
+    dedupe: ["drizzle-orm"],
+  },
 })


### PR DESCRIPTION
The #36 deploy failed building **apps/www**:

```
3: import { BetterAuthError } from "@better-auth/core/error";
[rollup] "BetterAuthError" is not exported by @better-auth/core/error
✗ Build failed — content-collections build && react-router build
```

**Cause:** the idp work bumped the shared `better-auth` to 1.6.15. better-auth's drizzle adapter is hoisted to the repo root, but `drizzle-orm` lives in `apps/www/node_modules` — so Vite couldn't resolve the adapter's optional `drizzle-orm` peer and failed to bundle better-auth for SSR.

**Fix:** add `resolve.dedupe: ["drizzle-orm"]` to `apps/www/vite.config.ts` (same fix already in `apps/idp`).

Verified: `apps/www` client + SSR build green locally.