### PR TITLE
idp: scoped API keys

### DIFF
--- a/apps/idp/app/db/schema.ts
+++ b/apps/idp/app/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
 
 // Better Auth tables (user / session / account / verification / passkey / org / oauth).
 // Generated from scripts/auth.gen.ts via `npm run auth:db:generate`.
@@ -86,6 +86,49 @@ export const userAppMetadata = sqliteTable(
   },
   (t) => [uniqueIndex("user_app_metadata_app_user_uidx").on(t.applicationId, t.userId)],
 )
+
+/**
+ * Scoped API key: a hashed, revocable, optionally-expiring credential that lets
+ * an agent or service drive the management API for *one application* with a
+ * specific permission set. Replaces the single global ADMIN_API_TOKEN (which
+ * stays as the superadmin escape hatch). The plaintext token is shown once at
+ * creation and never stored — only its SHA-256 hash and a non-secret prefix
+ * (for identification in the UI) are persisted.
+ */
+export const apiKey = sqliteTable(
+  "api_key",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    // The app this key administers — matches oauth_client.metadata.app and the
+    // applicationId workspaces/members are scoped by.
+    applicationId: text("application_id").notNull(),
+    name: text("name").notNull(),
+    // First chars of the token (e.g. "wim_a1b2c3d4"), shown so a key is
+    // identifiable in the UI. Not a secret.
+    prefix: text("prefix").notNull(),
+    // SHA-256 (hex) of the full token. The lookup key on every request.
+    keyHash: text("key_hash").notNull().unique(),
+    // Granted IdP-management permissions (subset of APP_PERMISSIONS).
+    permissions: text("permissions", { mode: "json" }).$type<string[]>().default([]),
+    createdByUserId: text("created_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    lastUsedAt: integer("last_used_at", { mode: "timestamp" }),
+    // Null = never expires.
+    expiresAt: integer("expires_at", { mode: "timestamp" }),
+    // Set on revoke; a revoked key authenticates no further. Kept (not deleted)
+    // so the key stays visible in the UI and for audit history.
+    revokedAt: integer("revoked_at", { mode: "timestamp" }),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  (t) => [index("api_key_app_idx").on(t.applicationId)],
+)
+
+export type ApiKey = typeof apiKey.$inferSelect
 
 /**
  * Placeholder app table from Phase 1. Kept for the migration history.

--- a/apps/idp/app/lib/admin.server.ts
+++ b/apps/idp/app/lib/admin.server.ts
@@ -42,15 +42,6 @@ export async function requireAdminSession(
   return session
 }
 
-/** API gate: require the management API bearer token. */
-export function requireAdminToken(request: Request, ctx: BaseServiceContext) {
-  const expected = ctx.getAppEnv("ADMIN_API_TOKEN")
-  const provided = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "")
-  if (!expected || !provided || provided !== expected) {
-    throw Response.json({ error: "unauthorized" }, { status: 401 })
-  }
-}
-
 /**
  * better-auth and drizzle's mode:"json" columns don't always agree on
  * serialization (values can come back already-parsed, once-, or twice-encoded),

--- a/apps/idp/app/lib/api-keys.server.ts
+++ b/apps/idp/app/lib/api-keys.server.ts
@@ -1,0 +1,275 @@
+import { and, desc, eq } from "drizzle-orm"
+
+import * as schema from "../db/schema"
+import { APP_PERMISSIONS, type AppPermission } from "./permissions"
+import type { BaseServiceContext } from "./services"
+
+/**
+ * Scoped API keys — hashed, revocable, optionally-expiring credentials that let
+ * an agent drive the management API for *one application* with a specific
+ * permission set. The plaintext token is shown once at creation; only its
+ * SHA-256 hash and a non-secret prefix are stored.
+ */
+
+const TOKEN_PREFIX = "wim_"
+// Bytes of entropy in the random part of a token.
+const TOKEN_BYTES = 32
+// How many chars of the token (including the "wim_" prefix) we keep for display.
+const DISPLAY_PREFIX_LEN = TOKEN_PREFIX.length + 8
+
+/** base64url without padding — URL/header safe, no `+` `/` `=`. */
+function base64url(bytes: Uint8Array): string {
+  let bin = ""
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+/** A fresh opaque token, e.g. `wim_X8f...`. */
+function generateToken(): string {
+  const bytes = new Uint8Array(TOKEN_BYTES)
+  crypto.getRandomValues(bytes)
+  return TOKEN_PREFIX + base64url(bytes)
+}
+
+/** SHA-256(token) as lowercase hex. The stored lookup key. */
+export async function hashToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token))
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("")
+}
+
+/** Keep only catalog permissions. */
+function sanitizePermissions(permissions: string[]): AppPermission[] {
+  return permissions.filter((p): p is AppPermission =>
+    (APP_PERMISSIONS as readonly string[]).includes(p),
+  )
+}
+
+export type ApiKeySummary = {
+  id: string
+  name: string
+  prefix: string
+  permissions: AppPermission[]
+  createdAt: Date
+  lastUsedAt: Date | null
+  expiresAt: Date | null
+  revokedAt: Date | null
+  /** Derived lifecycle state for the UI. */
+  status: "active" | "expired" | "revoked"
+}
+
+function statusOf(row: { revokedAt: Date | null; expiresAt: Date | null }, now: Date) {
+  if (row.revokedAt) return "revoked" as const
+  if (row.expiresAt && row.expiresAt.getTime() <= now.getTime()) return "expired" as const
+  return "active" as const
+}
+
+/** Keys for one application, newest first. Never returns the hash. */
+export async function listApiKeys(
+  ctx: BaseServiceContext,
+  app: string,
+): Promise<ApiKeySummary[]> {
+  const now = new Date()
+  const rows = await ctx.db
+    .select({
+      id: schema.apiKey.id,
+      name: schema.apiKey.name,
+      prefix: schema.apiKey.prefix,
+      permissions: schema.apiKey.permissions,
+      createdAt: schema.apiKey.createdAt,
+      lastUsedAt: schema.apiKey.lastUsedAt,
+      expiresAt: schema.apiKey.expiresAt,
+      revokedAt: schema.apiKey.revokedAt,
+    })
+    .from(schema.apiKey)
+    .where(eq(schema.apiKey.applicationId, app))
+    .orderBy(desc(schema.apiKey.createdAt))
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    prefix: r.prefix,
+    permissions: sanitizePermissions(r.permissions ?? []),
+    createdAt: r.createdAt,
+    lastUsedAt: r.lastUsedAt ?? null,
+    expiresAt: r.expiresAt ?? null,
+    revokedAt: r.revokedAt ?? null,
+    status: statusOf({ revokedAt: r.revokedAt ?? null, expiresAt: r.expiresAt ?? null }, now),
+  }))
+}
+
+/**
+ * Mints a new key for `app`. Returns the plaintext `token` exactly once — it is
+ * never recoverable afterwards. `permissions` is filtered to the catalog.
+ */
+export async function createApiKey(
+  ctx: BaseServiceContext,
+  input: {
+    app: string
+    name: string
+    permissions: string[]
+    createdByUserId: string
+    expiresAt?: Date | null
+  },
+): Promise<{ id: string; token: string; prefix: string }> {
+  const token = generateToken()
+  const keyHash = await hashToken(token)
+  const prefix = token.slice(0, DISPLAY_PREFIX_LEN)
+  const id = crypto.randomUUID()
+
+  await ctx.db.insert(schema.apiKey).values({
+    id,
+    applicationId: input.app,
+    name: input.name.trim() || "Untitled key",
+    prefix,
+    keyHash,
+    permissions: sanitizePermissions(input.permissions),
+    createdByUserId: input.createdByUserId,
+    expiresAt: input.expiresAt ?? null,
+  })
+
+  return { id, token, prefix }
+}
+
+/** Revokes a key (idempotent). Scoped to `app` so one app can't revoke another's. */
+export async function revokeApiKey(
+  ctx: BaseServiceContext,
+  input: { app: string; id: string },
+): Promise<{ ok: true } | { error: string }> {
+  const [row] = await ctx.db
+    .select({ id: schema.apiKey.id, revokedAt: schema.apiKey.revokedAt })
+    .from(schema.apiKey)
+    .where(and(eq(schema.apiKey.id, input.id), eq(schema.apiKey.applicationId, input.app)))
+    .limit(1)
+  if (!row) return { error: "Key not found." }
+  if (!row.revokedAt) {
+    await ctx.db
+      .update(schema.apiKey)
+      .set({ revokedAt: new Date() })
+      .where(eq(schema.apiKey.id, input.id))
+  }
+  return { ok: true }
+}
+
+/**
+ * The principal behind a management-API request. Either the superadmin token
+ * (the static ADMIN_API_TOKEN — every app, every permission) or a scoped key
+ * bound to one application with an explicit permission set.
+ */
+export type ApiPrincipal = {
+  kind: "superadmin" | "key"
+  /** The app a scoped key is bound to; null for superadmin (all apps). */
+  applicationId: string | null
+  keyId: string | null
+  /** Can this principal perform `permission` against `app`? */
+  can: (app: string, permission: AppPermission) => boolean
+}
+
+function extractBearer(request: Request): string | null {
+  const header = request.headers.get("authorization")
+  if (!header) return null
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim())
+  return match ? match[1].trim() : null
+}
+
+/** Constant-time string compare (avoids leaking the admin token via timing). */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let mismatch = 0
+  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return mismatch === 0
+}
+
+/**
+ * Resolves the bearer token on `request` to an {@link ApiPrincipal}, or null if
+ * absent/invalid/expired/revoked. The static ADMIN_API_TOKEN authenticates as
+ * superadmin; anything else is hashed and looked up in `api_key`. A successful
+ * scoped-key lookup bumps `lastUsedAt` (best effort).
+ */
+export async function authenticateApiKey(
+  request: Request,
+  ctx: BaseServiceContext,
+): Promise<ApiPrincipal | null> {
+  const token = extractBearer(request)
+  if (!token) return null
+
+  const superToken = ctx.getAppEnv("ADMIN_API_TOKEN")
+  if (superToken && timingSafeEqual(token, superToken)) {
+    return { kind: "superadmin", applicationId: null, keyId: null, can: () => true }
+  }
+
+  // Only opaque keys we issued are worth a DB round-trip.
+  if (!token.startsWith(TOKEN_PREFIX)) return null
+
+  const keyHash = await hashToken(token)
+  const [row] = await ctx.db
+    .select({
+      id: schema.apiKey.id,
+      applicationId: schema.apiKey.applicationId,
+      permissions: schema.apiKey.permissions,
+      expiresAt: schema.apiKey.expiresAt,
+      revokedAt: schema.apiKey.revokedAt,
+    })
+    .from(schema.apiKey)
+    .where(eq(schema.apiKey.keyHash, keyHash))
+    .limit(1)
+
+  if (!row) return null
+  if (row.revokedAt) return null
+  if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) return null
+
+  const granted = sanitizePermissions(row.permissions ?? [])
+
+  // Best effort — a failed lastUsedAt update must not deny an otherwise-valid key.
+  ctx.db
+    .update(schema.apiKey)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(schema.apiKey.id, row.id))
+    .then(undefined, (err) =>
+      ctx.logger.warn("apikey.last_used_update_failed", {
+        keyId: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+
+  return {
+    kind: "key",
+    applicationId: row.applicationId,
+    keyId: row.id,
+    can: (app, permission) => app === row.applicationId && granted.includes(permission),
+  }
+}
+
+/**
+ * Management-API gate. Authenticates the bearer token and (optionally) requires
+ * `permission` on `app`. Throws a JSON 401/403 Response on failure; returns the
+ * principal otherwise. Superadmins pass everything.
+ */
+export async function requireApiPrincipal(
+  request: Request,
+  ctx: BaseServiceContext,
+  required?: { app: string; permission: AppPermission },
+): Promise<ApiPrincipal> {
+  const principal = await authenticateApiKey(request, ctx)
+  if (!principal) {
+    throw Response.json({ error: "unauthorized" }, { status: 401 })
+  }
+  if (required && !principal.can(required.app, required.permission)) {
+    throw Response.json({ error: "forbidden" }, { status: 403 })
+  }
+  return principal
+}
+
+/**
+ * Gate for cross-app (global) management endpoints — only the superadmin token
+ * may list every app/user/workspace. Scoped keys are app-bound and get 403.
+ */
+export async function requireSuperadminApi(
+  request: Request,
+  ctx: BaseServiceContext,
+): Promise<ApiPrincipal> {
+  const principal = await requireApiPrincipal(request, ctx)
+  if (principal.kind !== "superadmin") {
+    throw Response.json({ error: "forbidden" }, { status: 403 })
+  }
+  return principal
+}

--- a/apps/idp/app/routes/api/applications.ts
+++ b/apps/idp/app/routes/api/applications.ts
@@ -1,8 +1,9 @@
 import type { Route } from "./+types/applications"
-import { listApplications, requireAdminToken } from "~/lib/admin.server"
+import { listApplications } from "~/lib/admin.server"
+import { requireSuperadminApi } from "~/lib/api-keys.server"
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  requireAdminToken(request, context)
+  await requireSuperadminApi(request, context)
   const applications = await listApplications(context)
   return Response.json({
     applications: applications.map((a) => ({ ...a, createdAt: a.createdAt.toISOString() })),

--- a/apps/idp/app/routes/api/openapi.ts
+++ b/apps/idp/app/routes/api/openapi.ts
@@ -31,12 +31,16 @@ export async function loader({ context }: Route.LoaderArgs) {
       title: "willy.im IdP — Management API",
       version: "1.0.0",
       description:
-        "Read-only management API for the willy.im identity provider. Authenticate with `Authorization: Bearer <ADMIN_API_TOKEN>`. Application registration is done in the admin console (better-auth ties client creation to an admin session).",
+        "Management API for the willy.im identity provider. Authenticate with `Authorization: Bearer <token>`. Two kinds of token: the superadmin `ADMIN_API_TOKEN` (every app) and per-app **scoped API keys** minted in the admin console (one app, a fixed permission set). The cross-app list endpoints below require the superadmin token. Application registration is done in the admin console (better-auth ties client creation to an admin session).",
     },
     servers: [{ url: baseUrl }],
     components: {
       securitySchemes: {
-        bearerAuth: { type: "http", scheme: "bearer" },
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          description: "Superadmin ADMIN_API_TOKEN or a scoped API key (wim_…).",
+        },
       },
     },
     paths: {

--- a/apps/idp/app/routes/api/users.ts
+++ b/apps/idp/app/routes/api/users.ts
@@ -1,8 +1,9 @@
 import type { Route } from "./+types/users"
-import { listUsers, requireAdminToken } from "~/lib/admin.server"
+import { listUsers } from "~/lib/admin.server"
+import { requireSuperadminApi } from "~/lib/api-keys.server"
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  requireAdminToken(request, context)
+  await requireSuperadminApi(request, context)
   const users = await listUsers(context)
   return Response.json({
     users: users.map((u) => ({ ...u, createdAt: new Date(u.createdAt).toISOString() })),

--- a/apps/idp/app/routes/api/workspaces.ts
+++ b/apps/idp/app/routes/api/workspaces.ts
@@ -1,8 +1,9 @@
 import type { Route } from "./+types/workspaces"
-import { listWorkspaces, requireAdminToken } from "~/lib/admin.server"
+import { listWorkspaces } from "~/lib/admin.server"
+import { requireSuperadminApi } from "~/lib/api-keys.server"
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  requireAdminToken(request, context)
+  await requireSuperadminApi(request, context)
   const workspaces = await listWorkspaces(context)
   return Response.json({
     workspaces: workspaces.map((w) => ({ ...w, createdAt: new Date(w.createdAt).toISOString() })),

--- a/apps/idp/app/routes/app/app-detail.tsx
+++ b/apps/idp/app/routes/app/app-detail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Form, Link, redirect, useActionData, useNavigation, useSubmit } from "react-router"
-import { ChevronRight, KeyRound, Loader2, Mail, Plus, Trash2, Users } from "lucide-react"
+import { ChevronRight, KeyRound, Loader2, Mail, Plus, Terminal, Trash2, Users } from "lucide-react"
 
 import type { Route } from "./+types/app-detail"
 import {
@@ -22,6 +22,7 @@ import {
   revokeInvitation,
   updateAppMember,
 } from "~/lib/members.server"
+import { createApiKey, listApiKeys, revokeApiKey } from "~/lib/api-keys.server"
 import { APP_PERMISSIONS, type AppRole } from "~/lib/permissions"
 import { requireAppPermission } from "~/lib/security.server"
 import { firstInvalidRedirectUri, parseUriList } from "~/lib/validate"
@@ -55,13 +56,14 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
   const application = await getApplication(context, params.clientId)
   if (!application) throw new Response("Application not found", { status: 404 })
   const app = application.app ?? ""
-  const [workspaces, people, members, invitations] = await Promise.all([
+  const [workspaces, people, members, invitations, apiKeys] = await Promise.all([
     app ? listWorkspacesForApp(context, app) : Promise.resolve([]),
     app ? listPeopleForApp(context, app) : Promise.resolve([]),
     app ? listAppMembers(context, app) : Promise.resolve([]),
     app ? listAppInvitations(context, app) : Promise.resolve([]),
+    app ? listApiKeys(context, app) : Promise.resolve([]),
   ])
-  return { application, workspaces, people, members, invitations }
+  return { application, workspaces, people, members, invitations, apiKeys }
 }
 
 export async function action({ request, context, params }: Route.ActionArgs) {
@@ -93,6 +95,39 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       }
     await updateApplicationRedirectUris(request, auth, clientId, redirectUris)
     return { ok: "redirects" }
+  }
+
+  if (intent === "create-api-key" || intent === "revoke-api-key") {
+    const application = await getApplication(context, clientId)
+    const app = application?.app
+    if (!app) return { error: "This application has no app key yet." }
+
+    if (intent === "create-api-key") {
+      const access = await requireAppPermission(request, context, auth, app, "apikey:create")
+      const name = String(form.get("name") ?? "").trim()
+      if (!name) return { error: "Give the key a name.", field: "key-name" }
+      const permissions = form.getAll("permissions").map(String).filter(Boolean)
+      if (permissions.length === 0)
+        return { error: "Select at least one permission.", field: "key-name" }
+      const days = Number(form.get("expiresInDays"))
+      const expiresAt =
+        Number.isFinite(days) && days > 0
+          ? new Date(Date.now() + days * 24 * 60 * 60 * 1000)
+          : null
+      const { token, prefix } = await createApiKey(context, {
+        app,
+        name,
+        permissions,
+        createdByUserId: access.user.id,
+        expiresAt,
+      })
+      return { createdApiKey: { token, prefix, name } }
+    }
+
+    // revoke-api-key
+    await requireAppPermission(request, context, auth, app, "apikey:revoke")
+    const res = await revokeApiKey(context, { app, id: String(form.get("keyId") ?? "") })
+    return "error" in res ? { error: res.error } : { ok: "api-key-revoked" }
   }
 
   if (intent === "create-workspace") {
@@ -187,7 +222,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 }
 
 export default function AppDetail({ loaderData }: Route.ComponentProps) {
-  const { application, workspaces, people, members, invitations } = loaderData
+  const { application, workspaces, people, members, invitations, apiKeys } = loaderData
   const actionData = useActionData<typeof action>()
   const nav = useNavigation()
   const submit = useSubmit()
@@ -196,6 +231,8 @@ export default function AppDetail({ loaderData }: Route.ComponentProps) {
 
   const rotatedSecret =
     actionData && "rotatedSecret" in actionData ? actionData.rotatedSecret : null
+  const createdApiKey =
+    actionData && "createdApiKey" in actionData ? actionData.createdApiKey : null
   const error = actionData && "error" in actionData ? actionData.error : null
   const field = actionData && "field" in actionData ? actionData.field : null
   const memberError =
@@ -436,6 +473,59 @@ export default function AppDetail({ loaderData }: Route.ComponentProps) {
               </Table>
             </div>
           ) : null}
+        </CardContent>
+      </Card>
+
+      {/* API keys — scoped management-API credentials */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Terminal className="text-muted-foreground size-4" />
+            API keys
+          </CardTitle>
+          <CardDescription>
+            Scoped credentials for the management API. A key carries a fixed set of permissions and
+            can only act on this app. The token is shown once at creation — store it somewhere safe.
+            Authenticate with <code className="font-mono text-xs">Authorization: Bearer &lt;token&gt;</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-6">
+          <CreateApiKeyForm
+            busy={busy}
+            error={field === "key-name" ? (error ?? null) : null}
+            disabled={!application.app}
+          />
+
+          {createdApiKey ? (
+            <div className="bg-muted rounded-md p-3 text-sm">
+              <p className="font-medium">
+                Key “{createdApiKey.name}” created — copy it now, it won't be shown again.
+              </p>
+              <p className="mt-1 font-mono text-xs break-all">{createdApiKey.token}</p>
+            </div>
+          ) : null}
+
+          {apiKeys.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No API keys yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Prefix</TableHead>
+                  <TableHead>Permissions</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last used</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {apiKeys.map((k) => (
+                  <ApiKeyRow key={k.id} apiKey={k} busy={busy} />
+                ))}
+              </TableBody>
+            </Table>
+          )}
         </CardContent>
       </Card>
 
@@ -717,6 +807,132 @@ function MemberRow({ member, busy }: { member: MemberRowData; busy: boolean }) {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+/** Mint a scoped API key: name + permission set + optional expiry. */
+function CreateApiKeyForm({
+  busy,
+  error,
+  disabled,
+}: {
+  busy: boolean
+  error: string | null
+  disabled: boolean
+}) {
+  return (
+    <Form method="post" className="flex flex-col gap-3 rounded-lg border p-4">
+      <input type="hidden" name="intent" value="create-api-key" />
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <Label htmlFor="key-name">Name</Label>
+          <Input
+            id="key-name"
+            name="name"
+            placeholder="kasso ingestion agent"
+            required
+            aria-invalid={!!error}
+            disabled={busy || disabled}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="key-expiry">Expires</Label>
+          <select id="key-expiry" name="expiresInDays" disabled={busy || disabled} className={selectClass}>
+            <option value="0">Never</option>
+            <option value="30">30 days</option>
+            <option value="90">90 days</option>
+            <option value="365">1 year</option>
+          </select>
+        </div>
+        <Button type="submit" disabled={busy || disabled}>
+          {busy ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+          Create key
+        </Button>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-muted-foreground text-xs">Permissions</Label>
+        <PermissionPicker selected={[]} disabled={busy || disabled} />
+      </div>
+      {error ? (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      ) : null}
+    </Form>
+  )
+}
+
+type ApiKeyRowData = {
+  id: string
+  name: string
+  prefix: string
+  permissions: string[]
+  status: "active" | "expired" | "revoked"
+  lastUsedAt: string | Date | null
+  expiresAt: string | Date | null
+}
+
+const statusVariant: Record<ApiKeyRowData["status"], "default" | "secondary" | "outline"> = {
+  active: "default",
+  expired: "outline",
+  revoked: "secondary",
+}
+
+/** A single API key row with an inline revoke confirmation. */
+function ApiKeyRow({ apiKey, busy }: { apiKey: ApiKeyRowData; busy: boolean }) {
+  const submit = useSubmit()
+  const fmtDate = (d: string | Date | null) =>
+    d ? new Date(d as string).toLocaleDateString() : "—"
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{apiKey.name}</TableCell>
+      <TableCell>
+        <code className="font-mono text-xs">{apiKey.prefix}…</code>
+      </TableCell>
+      <TableCell className="text-muted-foreground max-w-[16rem] text-xs">
+        {apiKey.permissions.join(", ") || "—"}
+      </TableCell>
+      <TableCell>
+        <Badge variant={statusVariant[apiKey.status]}>{apiKey.status}</Badge>
+      </TableCell>
+      <TableCell className="text-muted-foreground text-xs">{fmtDate(apiKey.lastUsedAt)}</TableCell>
+      <TableCell className="text-right whitespace-nowrap">
+        {apiKey.status === "revoked" ? (
+          <span className="text-muted-foreground text-xs">—</span>
+        ) : (
+          <AlertDialog>
+            <AlertDialogTrigger
+              render={
+                <Button variant="ghost" size="sm" className="text-destructive" disabled={busy}>
+                  <Trash2 className="size-3.5" />
+                  Revoke
+                </Button>
+              }
+            />
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Revoke “{apiKey.name}”?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  The key stops working immediately. Any agent using it will start getting 401s.
+                  This can't be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  onClick={() =>
+                    submit({ intent: "revoke-api-key", keyId: apiKey.id }, { method: "post" })
+                  }
+                >
+                  Revoke
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
       </TableCell>
     </TableRow>
   )

--- a/apps/idp/drizzle/0006_massive_gauntlet.sql
+++ b/apps/idp/drizzle/0006_massive_gauntlet.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `api_key` (
+	`id` text PRIMARY KEY NOT NULL,
+	`application_id` text NOT NULL,
+	`name` text NOT NULL,
+	`prefix` text NOT NULL,
+	`key_hash` text NOT NULL,
+	`permissions` text DEFAULT '[]',
+	`created_by_user_id` text,
+	`last_used_at` integer,
+	`expires_at` integer,
+	`revoked_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_key_key_hash_unique` ON `api_key` (`key_hash`);--> statement-breakpoint
+CREATE INDEX `api_key_app_idx` ON `api_key` (`application_id`);

--- a/apps/idp/drizzle/meta/0006_snapshot.json
+++ b/apps/idp/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1885 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a64217cc-c5bc-4bb1-9d05-4c67a89a4d02",
+  "prevId": "d7148e7a-02e5-45e3-89c7-ff9dcbc92c0f",
+  "tables": {
+    "api_key": {
+      "name": "api_key",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "api_key_app_idx": {
+          "name": "api_key_app_idx",
+          "columns": [
+            "application_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_meta": {
+      "name": "app_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_invitation": {
+      "name": "application_invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_invitation_token_unique": {
+          "name": "application_invitation_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "application_invitation_app_email_uidx": {
+          "name": "application_invitation_app_email_uidx",
+          "columns": [
+            "application_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_invitation_invited_by_user_id_user_id_fk": {
+          "name": "application_invitation_invited_by_user_id_user_id_fk",
+          "tableFrom": "application_invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_member": {
+      "name": "application_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_member_app_user_uidx": {
+          "name": "application_member_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_member_user_id_user_id_fk": {
+          "name": "application_member_user_id_user_id_fk",
+          "tableFrom": "application_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_app_metadata": {
+      "name": "user_app_metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_app_metadata_app_user_uidx": {
+          "name": "user_app_metadata_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_app_metadata_user_id_user_id_fk": {
+          "name": "user_app_metadata_user_id_user_id_fk",
+          "tableFrom": "user_app_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_token": {
+      "name": "oauth_access_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consent": {
+      "name": "oauth_consent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/idp/drizzle/meta/_journal.json
+++ b/apps/idp/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781065501025,
       "tag": "0005_normal_korath",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1781067098557,
+      "tag": "0006_massive_gauntlet",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Part of #33 — **Next: programmatic + safety → Scoped API keys**.

Hashed, revocable, optionally-expiring management-API credentials scoped to **one application** with an explicit permission set. Replaces reliance on the single global `ADMIN_API_TOKEN` (kept as the superadmin escape hatch), so an agent can be handed a key that manages only its own app.

### What's in here
- **`api_key` table** (migration `0006`): `application_id`, `name`, non-secret `prefix`, unique SHA-256 `key_hash`, `permissions[]`, `created_by_user_id`, and `last_used_at` / `expires_at` / `revoked_at` timestamps.
- **`lib/api-keys.server.ts`**
  - Opaque `wim_` tokens — 32 bytes of entropy, base64url; SHA-256 hashing via Web Crypto. The plaintext is shown **once** at creation and never stored.
  - `createApiKey` / `listApiKeys` / `revokeApiKey` (revoke scoped to the owning app).
  - **`authenticateApiKey()` → `ApiPrincipal`**: resolves a bearer token to either the superadmin token (constant-time compare → every app/permission) or a scoped key (expiry + revocation checked, `can(app, permission)`), bumping `last_used_at` best-effort. `requireApiPrincipal` / `requireSuperadminApi` route gates.
- **Management API**: the cross-app list endpoints (`/applications`, `/users`, `/workspaces`) now require the superadmin token; scoped keys are app-bound (the write API in the next PR consumes them). OpenAPI description + bearer scheme updated.
- **Admin console**: an *API keys* section on app detail — create (name, permission picker, optional expiry), token shown once, list with status (active/expired/revoked) + last-used, revoke behind a confirm. Gated on `apikey:create` / `apikey:revoke`.

### Validation
- `npm run typecheck` passes.
- Token round-trip verified out-of-band: 47-char `wim_…` token, 64-hex stable hash, distinct tokens → distinct hashes, header/URL-safe charset.

### Notes
- Stacked on `wovalle/readme-coverage-check`, which holds the pre-existing **member management + invitations** working-tree work (the base of this stack — not authored in this PR). Review against that base.
- Migration generated with `npm run db:generate` (never hand-edited).