### PR TITLE
idp: write management API (scoped-key authenticated)

### DIFF
--- a/apps/idp/app/lib/admin.server.ts
+++ b/apps/idp/app/lib/admin.server.ts
@@ -260,3 +260,36 @@ export async function createWorkspace(
     body: { name: input.name, slug: input.slug, applicationId: input.applicationId },
   })
 }
+
+/**
+ * Session-less workspace creation for the management API. Better Auth's
+ * createOrganization needs a user session (it makes the caller the owner); a
+ * scoped API key has no user, so the row is inserted directly. Members are
+ * added separately (via the member endpoints / invitations). Slug must be
+ * unique across all apps (the organization table enforces it).
+ */
+export async function createWorkspaceForApp(
+  ctx: BaseServiceContext,
+  input: { app: string; name: string; slug: string },
+): Promise<{ id: string; name: string; slug: string } | { error: string }> {
+  const slug = input.slug.trim().toLowerCase()
+  const name = input.name.trim()
+  if (!name || !slug) return { error: "Workspace name and slug are required." }
+
+  const [clash] = await ctx.db
+    .select({ id: schema.organization.id })
+    .from(schema.organization)
+    .where(eq(schema.organization.slug, slug))
+    .limit(1)
+  if (clash) return { error: `Slug "${slug}" is already taken.` }
+
+  const id = crypto.randomUUID()
+  await ctx.db.insert(schema.organization).values({
+    id,
+    name,
+    slug,
+    applicationId: input.app,
+    createdAt: new Date(),
+  })
+  return { id, name, slug }
+}

--- a/apps/idp/app/lib/api-schemas.ts
+++ b/apps/idp/app/lib/api-schemas.ts
@@ -28,3 +28,47 @@ export const WorkspaceSchema = z.object({
 export const ApplicationListSchema = z.object({ applications: z.array(ApplicationSchema) })
 export const UserListSchema = z.object({ users: z.array(UserSchema) })
 export const WorkspaceListSchema = z.object({ workspaces: z.array(WorkspaceSchema) })
+
+// --- Write management API (scoped-key authenticated, per-app) ---
+
+export const RoleSchema = z.enum(["admin", "member"])
+
+export const MemberSchema = z.object({
+  userId: z.string(),
+  email: z.string(),
+  name: z.string().nullable(),
+  role: RoleSchema,
+  permissions: z.array(z.string()),
+})
+export const MemberListSchema = z.object({ members: z.array(MemberSchema) })
+
+/** Add (existing user) or invite (new email) an app member. */
+export const InviteMemberInput = z.object({
+  email: z.string().email(),
+  role: RoleSchema.default("member"),
+  permissions: z.array(z.string()).default([]),
+})
+export const InviteMemberResult = z.object({
+  // "added" = existing user joined now; "invited" = pending invite emailed.
+  result: z.enum(["added", "invited"]),
+})
+
+export const UpdateMemberInput = z.object({
+  role: RoleSchema,
+  permissions: z.array(z.string()).default([]),
+})
+
+export const CreateWorkspaceInput = z.object({
+  name: z.string().min(1),
+  slug: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9-]+$/, "lowercase letters, numbers and dashes only"),
+})
+export const WorkspaceCreatedSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+})
+
+export const OkSchema = z.object({ ok: z.literal(true) })

--- a/apps/idp/app/lib/api.server.ts
+++ b/apps/idp/app/lib/api.server.ts
@@ -1,0 +1,34 @@
+import type { z } from "zod"
+
+/**
+ * Parses and validates a JSON request body for the management API. Throws a JSON
+ * error Response (400 for unparseable, 422 for schema violations) that the route
+ * lets bubble up to the RR error boundary — callers get a structured body.
+ */
+export async function readJson<S extends z.ZodType>(
+  request: Request,
+  schema: S,
+): Promise<z.infer<S>> {
+  let raw: unknown
+  try {
+    raw = await request.json()
+  } catch {
+    throw Response.json({ error: "invalid_json" }, { status: 400 })
+  }
+  const parsed = schema.safeParse(raw)
+  if (!parsed.success) {
+    throw Response.json(
+      { error: "validation_error", issues: parsed.error.issues },
+      { status: 422 },
+    )
+  }
+  return parsed.data
+}
+
+/** 405 for an unsupported method on a resource route. */
+export function methodNotAllowed(allow: string[]): Response {
+  return Response.json(
+    { error: "method_not_allowed" },
+    { status: 405, headers: { Allow: allow.join(", ") } },
+  )
+}

--- a/apps/idp/app/lib/members.server.ts
+++ b/apps/idp/app/lib/members.server.ts
@@ -62,7 +62,8 @@ export async function addOrInviteAppMember(
     email: string
     role: AppRole
     permissions: string[]
-    invitedByUserId: string
+    // Null for machine callers (a scoped API key / superadmin token has no user).
+    invitedByUserId: string | null
     origin: string
   },
 ): Promise<InviteResult> {

--- a/apps/idp/app/routes.ts
+++ b/apps/idp/app/routes.ts
@@ -20,10 +20,15 @@ export default [
     route("account", "routes/app/account.tsx"),
   ]),
 
-  // Management API (Bearer ADMIN_API_TOKEN) + OpenAPI docs.
+  // Management API (Bearer: superadmin ADMIN_API_TOKEN or scoped API key) + docs.
+  // Cross-app reads (superadmin only):
   route("api/v1/applications", "routes/api/applications.ts"),
   route("api/v1/users", "routes/api/users.ts"),
   route("api/v1/workspaces", "routes/api/workspaces.ts"),
+  // Per-app writes/reads (scoped-key authenticated, permission-checked):
+  route("api/v1/apps/:app/members", "routes/api/apps.$app.members.ts"),
+  route("api/v1/apps/:app/members/:userId", "routes/api/apps.$app.members.$userId.ts"),
+  route("api/v1/apps/:app/workspaces", "routes/api/apps.$app.workspaces.ts"),
   route("api/openapi.json", "routes/api/openapi.ts"),
   route("api/docs", "routes/api/docs.tsx"),
 ] satisfies RouteConfig

--- a/apps/idp/app/routes/api/apps.$app.members.$userId.ts
+++ b/apps/idp/app/routes/api/apps.$app.members.$userId.ts
@@ -1,0 +1,41 @@
+import type { Route } from "./+types/apps.$app.members.$userId"
+import { requireApiPrincipal } from "~/lib/api-keys.server"
+import { readJson } from "~/lib/api.server"
+import { UpdateMemberInput } from "~/lib/api-schemas"
+import { removeAppMember, updateAppMember } from "~/lib/members.server"
+
+/**
+ * PATCH — update a member's role + permissions (member:manage).
+ * DELETE — remove a member (member:manage).
+ * Both guard the last admin (handled in members.server).
+ */
+export async function action({ request, context, params }: Route.ActionArgs) {
+  const { app, userId } = params
+
+  if (request.method === "PATCH" || request.method === "PUT") {
+    await requireApiPrincipal(request, context, { app, permission: "member:manage" })
+    const body = await readJson(request, UpdateMemberInput)
+    const res = await updateAppMember(context, {
+      app,
+      userId,
+      role: body.role,
+      permissions: body.permissions,
+    })
+    return "error" in res
+      ? Response.json({ error: res.error }, { status: 409 })
+      : Response.json({ ok: true })
+  }
+
+  if (request.method === "DELETE") {
+    await requireApiPrincipal(request, context, { app, permission: "member:manage" })
+    const res = await removeAppMember(context, { app, userId })
+    return "error" in res
+      ? Response.json({ error: res.error }, { status: 409 })
+      : Response.json({ ok: true })
+  }
+
+  return Response.json(
+    { error: "method_not_allowed" },
+    { status: 405, headers: { Allow: "PATCH, DELETE" } },
+  )
+}

--- a/apps/idp/app/routes/api/apps.$app.members.ts
+++ b/apps/idp/app/routes/api/apps.$app.members.ts
@@ -1,0 +1,37 @@
+import type { Route } from "./+types/apps.$app.members"
+import { listAppMembers } from "~/lib/admin.server"
+import { requireApiPrincipal } from "~/lib/api-keys.server"
+import { readJson } from "~/lib/api.server"
+import { InviteMemberInput } from "~/lib/api-schemas"
+import { addOrInviteAppMember } from "~/lib/members.server"
+
+/** GET — list this app's members. Requires member:read. */
+export async function loader({ request, context, params }: Route.LoaderArgs) {
+  await requireApiPrincipal(request, context, { app: params.app, permission: "member:read" })
+  const members = await listAppMembers(context, params.app)
+  return Response.json({
+    members: members.map((m) => ({ ...m, permissions: m.permissions ?? [] })),
+  })
+}
+
+/** POST — add (existing user) or invite (new email) a member. Requires member:invite. */
+export async function action({ request, context, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "method_not_allowed" }, { status: 405, headers: { Allow: "POST" } })
+  }
+  await requireApiPrincipal(request, context, { app: params.app, permission: "member:invite" })
+  const body = await readJson(request, InviteMemberInput)
+
+  const res = await addOrInviteAppMember(context, {
+    app: params.app,
+    email: body.email,
+    role: body.role,
+    permissions: body.permissions,
+    invitedByUserId: null,
+    origin: new URL(request.url).origin,
+  })
+  if (res.kind === "already-member") {
+    return Response.json({ error: "already_member" }, { status: 409 })
+  }
+  return Response.json({ result: res.kind }, { status: 201 })
+}

--- a/apps/idp/app/routes/api/apps.$app.workspaces.ts
+++ b/apps/idp/app/routes/api/apps.$app.workspaces.ts
@@ -1,0 +1,34 @@
+import type { Route } from "./+types/apps.$app.workspaces"
+import { createWorkspaceForApp, listWorkspacesForApp } from "~/lib/admin.server"
+import { requireApiPrincipal } from "~/lib/api-keys.server"
+import { readJson } from "~/lib/api.server"
+import { CreateWorkspaceInput } from "~/lib/api-schemas"
+
+/** GET — list this app's workspaces. Requires workspace:read. */
+export async function loader({ request, context, params }: Route.LoaderArgs) {
+  await requireApiPrincipal(request, context, { app: params.app, permission: "workspace:read" })
+  const workspaces = await listWorkspacesForApp(context, params.app)
+  return Response.json({
+    workspaces: workspaces.map((w) => ({
+      ...w,
+      createdAt: new Date(w.createdAt as unknown as string).toISOString(),
+    })),
+  })
+}
+
+/** POST — create a workspace (tenant) in this app. Requires workspace:create. */
+export async function action({ request, context, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "method_not_allowed" }, { status: 405, headers: { Allow: "POST" } })
+  }
+  await requireApiPrincipal(request, context, { app: params.app, permission: "workspace:create" })
+  const body = await readJson(request, CreateWorkspaceInput)
+  const res = await createWorkspaceForApp(context, {
+    app: params.app,
+    name: body.name,
+    slug: body.slug,
+  })
+  return "error" in res
+    ? Response.json({ error: res.error }, { status: 409 })
+    : Response.json(res, { status: 201 })
+}

--- a/apps/idp/app/routes/api/openapi.ts
+++ b/apps/idp/app/routes/api/openapi.ts
@@ -3,7 +3,14 @@ import { z } from "zod"
 import type { Route } from "./+types/openapi"
 import {
   ApplicationListSchema,
+  CreateWorkspaceInput,
+  InviteMemberInput,
+  InviteMemberResult,
+  MemberListSchema,
+  OkSchema,
+  UpdateMemberInput,
   UserListSchema,
+  WorkspaceCreatedSchema,
   WorkspaceListSchema,
 } from "~/lib/api-schemas"
 
@@ -20,6 +27,60 @@ const bearerGet = (summary: string, responseSchema: z.ZodType) => ({
       },
       "401": { description: "Missing or invalid bearer token" },
     },
+  },
+})
+
+/** Path param shared by all per-app operations. */
+const appParam = {
+  name: "app",
+  in: "path",
+  required: true,
+  description: "Application key (oauth_client.metadata.app).",
+  schema: { type: "string" },
+}
+const userIdParam = {
+  name: "userId",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+}
+
+const jsonContent = (schema: z.ZodType) => ({
+  content: { "application/json": { schema: json(schema) } },
+})
+
+const scopedGet = (summary: string, permission: string, responseSchema: z.ZodType) => ({
+  summary,
+  description: `Requires \`${permission}\` on the path app (or the superadmin token).`,
+  security: [{ bearerAuth: [] }],
+  parameters: [appParam],
+  responses: {
+    "200": { description: "OK", ...jsonContent(responseSchema) },
+    "401": { description: "Missing or invalid bearer token" },
+    "403": { description: "Key lacks the permission / is bound to another app" },
+  },
+})
+
+const scopedWrite = (opts: {
+  summary: string
+  permission: string
+  input?: z.ZodType
+  success: { code: "200" | "201"; schema: z.ZodType }
+  extraParams?: object[]
+}) => ({
+  summary: opts.summary,
+  description: `Requires \`${opts.permission}\` on the path app (or the superadmin token).`,
+  security: [{ bearerAuth: [] }],
+  parameters: [appParam, ...(opts.extraParams ?? [])],
+  ...(opts.input
+    ? { requestBody: { required: true, ...jsonContent(opts.input) } }
+    : {}),
+  responses: {
+    [opts.success.code]: { description: "OK", ...jsonContent(opts.success.schema) },
+    "401": { description: "Missing or invalid bearer token" },
+    "403": { description: "Key lacks the permission / is bound to another app" },
+    "409": { description: "Conflict (already a member, last admin, slug taken, …)" },
+    "422": { description: "Body failed validation" },
   },
 })
 
@@ -47,6 +108,40 @@ export async function loader({ context }: Route.LoaderArgs) {
       "/api/v1/applications": bearerGet("List registered applications", ApplicationListSchema),
       "/api/v1/users": bearerGet("List users", UserListSchema),
       "/api/v1/workspaces": bearerGet("List workspaces", WorkspaceListSchema),
+
+      "/api/v1/apps/{app}/members": {
+        get: scopedGet("List app members", "member:read", MemberListSchema),
+        post: scopedWrite({
+          summary: "Add or invite a member",
+          permission: "member:invite",
+          input: InviteMemberInput,
+          success: { code: "201", schema: InviteMemberResult },
+        }),
+      },
+      "/api/v1/apps/{app}/members/{userId}": {
+        patch: scopedWrite({
+          summary: "Update a member's role + permissions",
+          permission: "member:manage",
+          input: UpdateMemberInput,
+          success: { code: "200", schema: OkSchema },
+          extraParams: [userIdParam],
+        }),
+        delete: scopedWrite({
+          summary: "Remove a member",
+          permission: "member:manage",
+          success: { code: "200", schema: OkSchema },
+          extraParams: [userIdParam],
+        }),
+      },
+      "/api/v1/apps/{app}/workspaces": {
+        get: scopedGet("List app workspaces", "workspace:read", WorkspaceListSchema),
+        post: scopedWrite({
+          summary: "Create a workspace",
+          permission: "workspace:create",
+          input: CreateWorkspaceInput,
+          success: { code: "201", schema: WorkspaceCreatedSchema },
+        }),
+      },
     },
   }
   return Response.json(doc)


### PR DESCRIPTION
Part of #33 — **Next: programmatic + safety → Write management API**. Stacked on #38.

Gives agents a scoped, permission-checked write surface over the management API. Every operation authenticates with a **scoped API key** (from #38) and is checked against the path app — a key bound to app *X* can only touch app *X*; the superadmin token passes everything. Each action is its own OpenAPI operation.

### Endpoints
| Method | Path | Permission |
|---|---|---|
| `GET` | `/api/v1/apps/{app}/members` | `member:read` |
| `POST` | `/api/v1/apps/{app}/members` | `member:invite` |
| `PATCH` | `/api/v1/apps/{app}/members/{userId}` | `member:manage` |
| `DELETE` | `/api/v1/apps/{app}/members/{userId}` | `member:manage` |
| `GET` | `/api/v1/apps/{app}/workspaces` | `workspace:read` |
| `POST` | `/api/v1/apps/{app}/workspaces` | `workspace:create` |

### Details
- Reuses the membership service (add-or-invite, update, remove) including the **last-admin guard**; `addOrInviteAppMember` now accepts a `null` inviter for machine callers.
- `createWorkspaceForApp()` — session-less workspace creation. Better Auth's `createOrganization` needs a user session (it makes the caller owner); a key has no user, so the row is inserted directly with a slug-uniqueness check. Members are added via the member endpoints.
- New `lib/api.server.ts`: JSON body parse + zod validation → structured `400` (unparseable) / `422` (schema). Zod input/output schemas drive both runtime validation and the OpenAPI bodies.
- OpenAPI doc gains the six operations with per-app params, request bodies, and `401/403/409/422` responses (visible in Scalar at `/api/docs`).

### Validation
- `npm run typecheck` passes.

Conflicts (already member, last admin, slug taken) return `409` with a message.