### PR TITLE
idp: audit log for privileged actions

### DIFF
--- a/apps/idp/app/db/schema.ts
+++ b/apps/idp/app/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm"
 import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
 
 // Better Auth tables (user / session / account / verification / passkey / org / oauth).
@@ -129,6 +130,44 @@ export const apiKey = sqliteTable(
 )
 
 export type ApiKey = typeof apiKey.$inferSelect
+
+/**
+ * Audit trail for privileged actions (member/key/workspace/app writes,
+ * impersonation). Mirrors the D1 `audit_logs` shape from @willyim/drizzle-audit
+ * (so it can be swapped to that package once it's a workspace dependency — same
+ * way permissions.ts mirrors @willyim/rbac), with two added columns we always
+ * want: application_id (scope — lets an app read only its own trail) and actor
+ * (a human-readable principal descriptor, since machine callers have no user_id).
+ */
+export const auditLog = sqliteTable(
+  "audit_logs",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    // The entity type touched, e.g. "api_key", "application_member", "organization".
+    tableName: text("table_name").notNull(),
+    // "create" | "update" | "delete" | "revoke" | "invite" | "impersonate" | …
+    operation: text("operation").notNull(),
+    // The affected entity's id (key id, user id, workspace id, …).
+    rowId: text("row_id"),
+    applicationId: text("application_id"),
+    // The human actor's user id when there is one; null for machine callers.
+    userId: text("user_id"),
+    // Principal descriptor: "user:<id>" | "apikey:<id>" | "superadmin-token".
+    actor: text("actor"),
+    oldData: text("old_data", { mode: "json" }),
+    newData: text("new_data", { mode: "json" }),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => [
+    index("audit_logs_application_id_idx").on(t.applicationId),
+    index("audit_logs_table_name_idx").on(t.tableName),
+    index("audit_logs_created_at_idx").on(t.createdAt),
+  ],
+)
+
+export type AuditLog = typeof auditLog.$inferSelect
 
 /**
  * Placeholder app table from Phase 1. Kept for the migration history.

--- a/apps/idp/app/lib/api-schemas.ts
+++ b/apps/idp/app/lib/api-schemas.ts
@@ -72,3 +72,14 @@ export const WorkspaceCreatedSchema = z.object({
 })
 
 export const OkSchema = z.object({ ok: z.literal(true) })
+
+export const AuditEntrySchema = z.object({
+  id: z.number(),
+  tableName: z.string(),
+  operation: z.string(),
+  rowId: z.string().nullable(),
+  userId: z.string().nullable(),
+  actor: z.string().nullable(),
+  createdAt: z.string(),
+})
+export const AuditListSchema = z.object({ entries: z.array(AuditEntrySchema) })

--- a/apps/idp/app/lib/audit.server.ts
+++ b/apps/idp/app/lib/audit.server.ts
@@ -1,0 +1,131 @@
+import { and, desc, eq } from "drizzle-orm"
+
+import * as schema from "../db/schema"
+import type { ApiPrincipal } from "./api-keys.server"
+import type { User } from "./auth.server"
+import type { BaseServiceContext } from "./services"
+
+/**
+ * Audit trail for privileged actions. Writes are best-effort: a failure to log
+ * must never break the action being audited. Mirrors the @willyim/drizzle-audit
+ * D1 schema (see schema.ts) so it can be swapped to the package later.
+ */
+
+/** Who performed an action, normalized for the `user_id` + `actor` columns. */
+export type Actor = {
+  /** Human user id, when there is one. Null for machine callers. */
+  userId: string | null
+  /** Descriptor: "user:<id>" | "apikey:<id>" | "superadmin-token". */
+  label: string
+}
+
+export function actorFromUser(user: Pick<User, "id">): Actor {
+  return { userId: user.id, label: `user:${user.id}` }
+}
+
+export function actorFromPrincipal(principal: ApiPrincipal): Actor {
+  if (principal.kind === "superadmin") return { userId: null, label: "superadmin-token" }
+  return { userId: null, label: `apikey:${principal.keyId}` }
+}
+
+export type AuditOperation =
+  | "create"
+  | "update"
+  | "delete"
+  | "revoke"
+  | "invite"
+  | "impersonate"
+
+export async function recordAudit(
+  ctx: BaseServiceContext,
+  entry: {
+    actor: Actor
+    /** Entity type, e.g. "api_key", "application_member", "organization". */
+    table: string
+    operation: AuditOperation
+    applicationId: string
+    rowId?: string | null
+    before?: unknown
+    after?: unknown
+  },
+): Promise<void> {
+  try {
+    await ctx.db.insert(schema.auditLog).values({
+      tableName: entry.table,
+      operation: entry.operation,
+      rowId: entry.rowId ?? null,
+      applicationId: entry.applicationId,
+      userId: entry.actor.userId,
+      actor: entry.actor.label,
+      oldData: entry.before ?? null,
+      newData: entry.after ?? null,
+    })
+  } catch (err) {
+    ctx.logger.warn("audit.record_failed", {
+      table: entry.table,
+      operation: entry.operation,
+      applicationId: entry.applicationId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+export type AuditEntry = {
+  id: number
+  tableName: string
+  operation: string
+  rowId: string | null
+  userId: string | null
+  actor: string | null
+  createdAt: string
+}
+
+/** Recent audit entries for one app, newest first. */
+export async function listAuditForApp(
+  ctx: BaseServiceContext,
+  app: string,
+  limit = 50,
+): Promise<AuditEntry[]> {
+  return ctx.db
+    .select({
+      id: schema.auditLog.id,
+      tableName: schema.auditLog.tableName,
+      operation: schema.auditLog.operation,
+      rowId: schema.auditLog.rowId,
+      userId: schema.auditLog.userId,
+      actor: schema.auditLog.actor,
+      createdAt: schema.auditLog.createdAt,
+    })
+    .from(schema.auditLog)
+    .where(eq(schema.auditLog.applicationId, app))
+    .orderBy(desc(schema.auditLog.id))
+    .limit(limit)
+}
+
+/** A single entity's history (e.g. one API key), newest first. */
+export async function listAuditForRow(
+  ctx: BaseServiceContext,
+  app: string,
+  table: string,
+  rowId: string,
+): Promise<AuditEntry[]> {
+  return ctx.db
+    .select({
+      id: schema.auditLog.id,
+      tableName: schema.auditLog.tableName,
+      operation: schema.auditLog.operation,
+      rowId: schema.auditLog.rowId,
+      userId: schema.auditLog.userId,
+      actor: schema.auditLog.actor,
+      createdAt: schema.auditLog.createdAt,
+    })
+    .from(schema.auditLog)
+    .where(
+      and(
+        eq(schema.auditLog.applicationId, app),
+        eq(schema.auditLog.tableName, table),
+        eq(schema.auditLog.rowId, rowId),
+      ),
+    )
+    .orderBy(desc(schema.auditLog.id))
+}

--- a/apps/idp/app/lib/permissions.ts
+++ b/apps/idp/app/lib/permissions.ts
@@ -19,6 +19,7 @@ export const APP_PERMISSIONS = [
   "apikey:read",
   "apikey:create",
   "apikey:revoke",
+  "audit:read",
   "user:impersonate",
 ] as const
 

--- a/apps/idp/app/routes.ts
+++ b/apps/idp/app/routes.ts
@@ -29,6 +29,7 @@ export default [
   route("api/v1/apps/:app/members", "routes/api/apps.$app.members.ts"),
   route("api/v1/apps/:app/members/:userId", "routes/api/apps.$app.members.$userId.ts"),
   route("api/v1/apps/:app/workspaces", "routes/api/apps.$app.workspaces.ts"),
+  route("api/v1/apps/:app/audit", "routes/api/apps.$app.audit.ts"),
   route("api/openapi.json", "routes/api/openapi.ts"),
   route("api/docs", "routes/api/docs.tsx"),
 ] satisfies RouteConfig

--- a/apps/idp/app/routes/api/apps.$app.audit.ts
+++ b/apps/idp/app/routes/api/apps.$app.audit.ts
@@ -1,0 +1,13 @@
+import type { Route } from "./+types/apps.$app.audit"
+import { requireApiPrincipal } from "~/lib/api-keys.server"
+import { listAuditForApp } from "~/lib/audit.server"
+
+/** GET — recent audit entries for this app (newest first). Requires audit:read. */
+export async function loader({ request, context, params }: Route.LoaderArgs) {
+  await requireApiPrincipal(request, context, { app: params.app, permission: "audit:read" })
+  const url = new URL(request.url)
+  const limitParam = Number(url.searchParams.get("limit"))
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 50
+  const entries = await listAuditForApp(context, params.app, limit)
+  return Response.json({ entries })
+}

--- a/apps/idp/app/routes/api/apps.$app.members.$userId.ts
+++ b/apps/idp/app/routes/api/apps.$app.members.$userId.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/apps.$app.members.$userId"
 import { requireApiPrincipal } from "~/lib/api-keys.server"
 import { readJson } from "~/lib/api.server"
 import { UpdateMemberInput } from "~/lib/api-schemas"
+import { actorFromPrincipal, recordAudit } from "~/lib/audit.server"
 import { removeAppMember, updateAppMember } from "~/lib/members.server"
 
 /**
@@ -13,7 +14,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const { app, userId } = params
 
   if (request.method === "PATCH" || request.method === "PUT") {
-    await requireApiPrincipal(request, context, { app, permission: "member:manage" })
+    const principal = await requireApiPrincipal(request, context, { app, permission: "member:manage" })
     const body = await readJson(request, UpdateMemberInput)
     const res = await updateAppMember(context, {
       app,
@@ -21,17 +22,30 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       role: body.role,
       permissions: body.permissions,
     })
-    return "error" in res
-      ? Response.json({ error: res.error }, { status: 409 })
-      : Response.json({ ok: true })
+    if ("error" in res) return Response.json({ error: res.error }, { status: 409 })
+    await recordAudit(context, {
+      actor: actorFromPrincipal(principal),
+      table: "application_member",
+      operation: "update",
+      applicationId: app,
+      rowId: userId,
+      after: { role: body.role, permissions: body.permissions },
+    })
+    return Response.json({ ok: true })
   }
 
   if (request.method === "DELETE") {
-    await requireApiPrincipal(request, context, { app, permission: "member:manage" })
+    const principal = await requireApiPrincipal(request, context, { app, permission: "member:manage" })
     const res = await removeAppMember(context, { app, userId })
-    return "error" in res
-      ? Response.json({ error: res.error }, { status: 409 })
-      : Response.json({ ok: true })
+    if ("error" in res) return Response.json({ error: res.error }, { status: 409 })
+    await recordAudit(context, {
+      actor: actorFromPrincipal(principal),
+      table: "application_member",
+      operation: "delete",
+      applicationId: app,
+      rowId: userId,
+    })
+    return Response.json({ ok: true })
   }
 
   return Response.json(

--- a/apps/idp/app/routes/api/apps.$app.members.ts
+++ b/apps/idp/app/routes/api/apps.$app.members.ts
@@ -3,6 +3,7 @@ import { listAppMembers } from "~/lib/admin.server"
 import { requireApiPrincipal } from "~/lib/api-keys.server"
 import { readJson } from "~/lib/api.server"
 import { InviteMemberInput } from "~/lib/api-schemas"
+import { actorFromPrincipal, recordAudit } from "~/lib/audit.server"
 import { addOrInviteAppMember } from "~/lib/members.server"
 
 /** GET — list this app's members. Requires member:read. */
@@ -19,7 +20,10 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return Response.json({ error: "method_not_allowed" }, { status: 405, headers: { Allow: "POST" } })
   }
-  await requireApiPrincipal(request, context, { app: params.app, permission: "member:invite" })
+  const principal = await requireApiPrincipal(request, context, {
+    app: params.app,
+    permission: "member:invite",
+  })
   const body = await readJson(request, InviteMemberInput)
 
   const res = await addOrInviteAppMember(context, {
@@ -33,5 +37,12 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   if (res.kind === "already-member") {
     return Response.json({ error: "already_member" }, { status: 409 })
   }
+  await recordAudit(context, {
+    actor: actorFromPrincipal(principal),
+    table: res.kind === "added" ? "application_member" : "application_invitation",
+    operation: "invite",
+    applicationId: params.app,
+    after: { email: body.email, role: body.role, permissions: body.permissions, result: res.kind },
+  })
   return Response.json({ result: res.kind }, { status: 201 })
 }

--- a/apps/idp/app/routes/api/apps.$app.workspaces.ts
+++ b/apps/idp/app/routes/api/apps.$app.workspaces.ts
@@ -3,6 +3,7 @@ import { createWorkspaceForApp, listWorkspacesForApp } from "~/lib/admin.server"
 import { requireApiPrincipal } from "~/lib/api-keys.server"
 import { readJson } from "~/lib/api.server"
 import { CreateWorkspaceInput } from "~/lib/api-schemas"
+import { actorFromPrincipal, recordAudit } from "~/lib/audit.server"
 
 /** GET — list this app's workspaces. Requires workspace:read. */
 export async function loader({ request, context, params }: Route.LoaderArgs) {
@@ -21,14 +22,24 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return Response.json({ error: "method_not_allowed" }, { status: 405, headers: { Allow: "POST" } })
   }
-  await requireApiPrincipal(request, context, { app: params.app, permission: "workspace:create" })
+  const principal = await requireApiPrincipal(request, context, {
+    app: params.app,
+    permission: "workspace:create",
+  })
   const body = await readJson(request, CreateWorkspaceInput)
   const res = await createWorkspaceForApp(context, {
     app: params.app,
     name: body.name,
     slug: body.slug,
   })
-  return "error" in res
-    ? Response.json({ error: res.error }, { status: 409 })
-    : Response.json(res, { status: 201 })
+  if ("error" in res) return Response.json({ error: res.error }, { status: 409 })
+  await recordAudit(context, {
+    actor: actorFromPrincipal(principal),
+    table: "organization",
+    operation: "create",
+    applicationId: params.app,
+    rowId: res.id,
+    after: { name: res.name, slug: res.slug },
+  })
+  return Response.json(res, { status: 201 })
 }

--- a/apps/idp/app/routes/api/openapi.ts
+++ b/apps/idp/app/routes/api/openapi.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import type { Route } from "./+types/openapi"
 import {
   ApplicationListSchema,
+  AuditListSchema,
   CreateWorkspaceInput,
   InviteMemberInput,
   InviteMemberResult,
@@ -141,6 +142,9 @@ export async function loader({ context }: Route.LoaderArgs) {
           input: CreateWorkspaceInput,
           success: { code: "201", schema: WorkspaceCreatedSchema },
         }),
+      },
+      "/api/v1/apps/{app}/audit": {
+        get: scopedGet("List recent audit entries", "audit:read", AuditListSchema),
       },
     },
   }

--- a/apps/idp/app/routes/app/app-detail.tsx
+++ b/apps/idp/app/routes/app/app-detail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Form, Link, redirect, useActionData, useNavigation, useSubmit } from "react-router"
-import { ChevronRight, KeyRound, Loader2, Mail, Plus, Terminal, Trash2, Users } from "lucide-react"
+import { ChevronRight, KeyRound, Loader2, Mail, Plus, ScrollText, Terminal, Trash2, Users } from "lucide-react"
 
 import type { Route } from "./+types/app-detail"
 import {
@@ -23,6 +23,7 @@ import {
   updateAppMember,
 } from "~/lib/members.server"
 import { createApiKey, listApiKeys, revokeApiKey } from "~/lib/api-keys.server"
+import { actorFromUser, listAuditForApp, recordAudit } from "~/lib/audit.server"
 import { APP_PERMISSIONS, type AppRole } from "~/lib/permissions"
 import { requireAppPermission } from "~/lib/security.server"
 import { firstInvalidRedirectUri, parseUriList } from "~/lib/validate"
@@ -56,18 +57,20 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
   const application = await getApplication(context, params.clientId)
   if (!application) throw new Response("Application not found", { status: 404 })
   const app = application.app ?? ""
-  const [workspaces, people, members, invitations, apiKeys] = await Promise.all([
+  const [workspaces, people, members, invitations, apiKeys, audit] = await Promise.all([
     app ? listWorkspacesForApp(context, app) : Promise.resolve([]),
     app ? listPeopleForApp(context, app) : Promise.resolve([]),
     app ? listAppMembers(context, app) : Promise.resolve([]),
     app ? listAppInvitations(context, app) : Promise.resolve([]),
     app ? listApiKeys(context, app) : Promise.resolve([]),
+    app ? listAuditForApp(context, app, 20) : Promise.resolve([]),
   ])
-  return { application, workspaces, people, members, invitations, apiKeys }
+  return { application, workspaces, people, members, invitations, apiKeys, audit }
 }
 
 export async function action({ request, context, params }: Route.ActionArgs) {
-  await requireAdminSession(request, context, context.services.auth)
+  const session = await requireAdminSession(request, context, context.services.auth)
+  const actor = actorFromUser(session.user)
   const auth = context.services.auth
   const clientId = params.clientId
   const form = await request.formData()
@@ -114,20 +117,37 @@ export async function action({ request, context, params }: Route.ActionArgs) {
         Number.isFinite(days) && days > 0
           ? new Date(Date.now() + days * 24 * 60 * 60 * 1000)
           : null
-      const { token, prefix } = await createApiKey(context, {
+      const { id, token, prefix } = await createApiKey(context, {
         app,
         name,
         permissions,
         createdByUserId: access.user.id,
         expiresAt,
       })
+      await recordAudit(context, {
+        actor,
+        table: "api_key",
+        operation: "create",
+        applicationId: app,
+        rowId: id,
+        after: { name, permissions, expiresAt: expiresAt?.toISOString() ?? null },
+      })
       return { createdApiKey: { token, prefix, name } }
     }
 
     // revoke-api-key
     await requireAppPermission(request, context, auth, app, "apikey:revoke")
-    const res = await revokeApiKey(context, { app, id: String(form.get("keyId") ?? "") })
-    return "error" in res ? { error: res.error } : { ok: "api-key-revoked" }
+    const keyId = String(form.get("keyId") ?? "")
+    const res = await revokeApiKey(context, { app, id: keyId })
+    if ("error" in res) return { error: res.error }
+    await recordAudit(context, {
+      actor,
+      table: "api_key",
+      operation: "revoke",
+      applicationId: app,
+      rowId: keyId,
+    })
+    return { ok: "api-key-revoked" }
   }
 
   if (intent === "create-workspace") {
@@ -137,6 +157,13 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     if (!name || !slug) return { error: "Workspace name and slug are required.", field: "ws-name" }
     try {
       await createWorkspace(request, auth, { name, slug, applicationId: app })
+      await recordAudit(context, {
+        actor,
+        table: "organization",
+        operation: "create",
+        applicationId: app,
+        after: { name, slug },
+      })
       return { ok: "workspace" }
     } catch (e) {
       return { error: e instanceof Error ? e.message : "Couldn't create workspace.", field: "ws-name" }
@@ -178,27 +205,51 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       })
       if (result.kind === "already-member")
         return { error: `${email} is already a member.`, field: "invite-email" }
+      await recordAudit(context, {
+        actor,
+        table: result.kind === "added" ? "application_member" : "application_invitation",
+        operation: "invite",
+        applicationId: app,
+        after: { email, role: readRole(form.get("role")), result: result.kind },
+      })
       return { ok: result.kind === "added" ? "member-added" : "member-invited" }
     }
 
     if (intent === "update-member") {
       await requireAppPermission(request, context, auth, app, "member:manage")
+      const userId = String(form.get("userId") ?? "")
+      const role = readRole(form.get("role"))
       const res = await updateAppMember(context, {
         app,
-        userId: String(form.get("userId") ?? ""),
-        role: readRole(form.get("role")),
+        userId,
+        role,
         permissions: readPermissions(),
       })
-      return "error" in res ? { error: res.error } : { ok: "member-updated" }
+      if ("error" in res) return { error: res.error }
+      await recordAudit(context, {
+        actor,
+        table: "application_member",
+        operation: "update",
+        applicationId: app,
+        rowId: userId,
+        after: { role, permissions: readPermissions() },
+      })
+      return { ok: "member-updated" }
     }
 
     if (intent === "remove-member") {
       await requireAppPermission(request, context, auth, app, "member:manage")
-      const res = await removeAppMember(context, {
-        app,
-        userId: String(form.get("userId") ?? ""),
+      const userId = String(form.get("userId") ?? "")
+      const res = await removeAppMember(context, { app, userId })
+      if ("error" in res) return { error: res.error }
+      await recordAudit(context, {
+        actor,
+        table: "application_member",
+        operation: "delete",
+        applicationId: app,
+        rowId: userId,
       })
-      return "error" in res ? { error: res.error } : { ok: "member-removed" }
+      return { ok: "member-removed" }
     }
 
     if (intent === "revoke-invite") {
@@ -222,7 +273,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 }
 
 export default function AppDetail({ loaderData }: Route.ComponentProps) {
-  const { application, workspaces, people, members, invitations, apiKeys } = loaderData
+  const { application, workspaces, people, members, invitations, apiKeys, audit } = loaderData
   const actionData = useActionData<typeof action>()
   const nav = useNavigation()
   const submit = useSubmit()
@@ -559,6 +610,54 @@ export default function AppDetail({ loaderData }: Route.ComponentProps) {
                     <TableCell className="text-muted-foreground">{p.workspace}</TableCell>
                     <TableCell>
                       <Badge variant="secondary">{p.role}</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Recent activity — audit trail */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ScrollText className="text-muted-foreground size-4" />
+            Recent activity
+          </CardTitle>
+          <CardDescription>
+            Privileged actions on this app — member, API key and workspace writes — with who did them.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {audit.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No activity yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>When</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead>Entity</TableHead>
+                  <TableHead>Actor</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {audit.map((e) => (
+                  <TableRow key={e.id}>
+                    <TableCell className="text-muted-foreground text-xs whitespace-nowrap">
+                      {new Date(`${e.createdAt.replace(" ", "T")}Z`).toLocaleString()}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{e.operation}</Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground font-mono text-xs">
+                      {e.tableName}
+                      {e.rowId ? <span className="opacity-60"> · {e.rowId.slice(0, 8)}…</span> : null}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground font-mono text-xs break-all">
+                      {e.actor ?? "—"}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/apps/idp/drizzle/0007_exotic_living_tribunal.sql
+++ b/apps/idp/drizzle/0007_exotic_living_tribunal.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `audit_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`table_name` text NOT NULL,
+	`operation` text NOT NULL,
+	`row_id` text,
+	`application_id` text,
+	`user_id` text,
+	`actor` text,
+	`old_data` text,
+	`new_data` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `audit_logs_application_id_idx` ON `audit_logs` (`application_id`);--> statement-breakpoint
+CREATE INDEX `audit_logs_table_name_idx` ON `audit_logs` (`table_name`);--> statement-breakpoint
+CREATE INDEX `audit_logs_created_at_idx` ON `audit_logs` (`created_at`);

--- a/apps/idp/drizzle/meta/0007_snapshot.json
+++ b/apps/idp/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1988 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e8de0d78-49a1-4a75-b250-f66fb843c791",
+  "prevId": "a64217cc-c5bc-4bb1-9d05-4c67a89a4d02",
+  "tables": {
+    "api_key": {
+      "name": "api_key",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "api_key_app_idx": {
+          "name": "api_key_app_idx",
+          "columns": [
+            "application_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_meta": {
+      "name": "app_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_invitation": {
+      "name": "application_invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_invitation_token_unique": {
+          "name": "application_invitation_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "application_invitation_app_email_uidx": {
+          "name": "application_invitation_app_email_uidx",
+          "columns": [
+            "application_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_invitation_invited_by_user_id_user_id_fk": {
+          "name": "application_invitation_invited_by_user_id_user_id_fk",
+          "tableFrom": "application_invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_member": {
+      "name": "application_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_member_app_user_uidx": {
+          "name": "application_member_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_member_user_id_user_id_fk": {
+          "name": "application_member_user_id_user_id_fk",
+          "tableFrom": "application_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_data": {
+          "name": "old_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_data": {
+          "name": "new_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "audit_logs_application_id_idx": {
+          "name": "audit_logs_application_id_idx",
+          "columns": [
+            "application_id"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_table_name_idx": {
+          "name": "audit_logs_table_name_idx",
+          "columns": [
+            "table_name"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_app_metadata": {
+      "name": "user_app_metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_app_metadata_app_user_uidx": {
+          "name": "user_app_metadata_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_app_metadata_user_id_user_id_fk": {
+          "name": "user_app_metadata_user_id_user_id_fk",
+          "tableFrom": "user_app_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_token": {
+      "name": "oauth_access_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consent": {
+      "name": "oauth_consent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/idp/drizzle/meta/_journal.json
+++ b/apps/idp/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781067098557,
       "tag": "0006_massive_gauntlet",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1781067648157,
+      "tag": "0007_exotic_living_tribunal",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Part of #33 — **Next: programmatic + safety → Audit log** ("required companion to admin writes + impersonation"). Stacked on #39.

Records every privileged write — member, API key and workspace changes, from **both** the admin console and the management API — to an `audit_logs` table, with who did it. Writes are **best-effort**: a logging failure never breaks the action being audited.

### On wiring `@willyim/drizzle-audit`
The roadmap says "wire `packages/drizzle_audit`". That package isn't a workspace member, ships **no built `dist`**, and pins **drizzle-orm `>=1.0.0-0`** while idp runs **0.44** — pulling it in directly risks an unverifiable broken build. So this follows the codebase's existing precedent (`permissions.ts` mirrors `@willyim/rbac` inline until it's a real dep): the `audit_logs` table uses **the package's exact D1 column shape**, so swapping to it later is mechanical. Happy to do the real wiring once the package is built + added to the workspace.

### What's in here
- **`audit_logs` table** (migration `0007`) — `table_name`, `operation`, `row_id`, `user_id`, `old_data`, `new_data`, `created_at` (package shape) **plus** `application_id` (scope, so an app reads only its own trail) and `actor` (principal descriptor — machine callers have no `user_id`).
- **`lib/audit.server.ts`** — `recordAudit()`; `actorFromUser` / `actorFromPrincipal` (console session user vs API-key / superadmin principal); `listAuditForApp` / `listAuditForRow`.
- **Wiring** — write API (member invite/update/remove, workspace create) and console actions (api key create/revoke, member invite/update/remove, workspace create).
- **Surfaces** — new `audit:read` permission; `GET /api/v1/apps/{app}/audit` (scoped, paginated via `?limit`) + OpenAPI op; a **Recent activity** card on app detail.

### Validation
- `npm run typecheck` passes.

Impersonation (next PR) records an `impersonate` operation through the same helper.