### PR TITLE
idp: scoped, audited impersonation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: idp-setup idp
+
+# One-time (or after a pull) setup for the idp app: install workspace deps,
+# generate Cloudflare worker types, and apply local D1 migrations.
+idp-setup:
+	npm install
+	npm run cf-typegen --workspace=idp
+	npm run db:migrate --workspace=idp
+
+# Run the idp app in development.
+idp:
+	npm run dev --workspace=idp

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ User (global)
   so they can fully replace app-managed key systems (e.g. tracker ingestion keys).
 - A management API (OpenAPI) so agents can provision users/workspaces on your behalf.
 
+### Custom domains (later)
+
+`idp.willy.im` is the one canonical IdP. A per-app domain (e.g. `idp.kasso.do`) is
+not a separate identity store — it's the same IdP served under the app's own
+origin so its session cookie is **first-party** (no third-party-cookie blocking).
+Two consequences to design around:
+
+- **Claim keys are host-independent.** Custom claims use a fixed `willy.im`
+  namespace (e.g. `https://willy.im/workspaces`), never the issuer host. The key
+  is a unique identifier, not a URL that's fetched, so it must stay constant no
+  matter which front served the token. Only `iss` reflects the actual host (clients
+  validate JWKS/discovery against it).
+- **Cookies are per-domain, so SSO is per-domain.** A session on `idp.kasso.do` is
+  a separate cookie jar from `idp.willy.im`. The trade is deliberate: first-party
+  cookies per app, at the cost of a shared sign-in not carrying across custom
+  domains. The OIDC flow itself is unaffected. To get both first-party cookies and
+  cross-app SSO later, the custom-domain fronts would silently authorize against a
+  canonical `idp.willy.im` session (`prompt=none`) — deferred.
+
 ## Status
 
 Built: email (magic-link + OTP) and passkey sign-in · OIDC provider

--- a/apps/idp/app/db/auth-schema.ts
+++ b/apps/idp/app/db/auth-schema.ts
@@ -22,6 +22,10 @@ export const user = sqliteTable("user", {
     .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
+  role: text("role"),
+  banned: integer("banned", { mode: "boolean" }).default(false),
+  banReason: text("ban_reason"),
+  banExpires: integer("ban_expires", { mode: "timestamp_ms" }),
 });
 
 export const session = sqliteTable(
@@ -42,6 +46,7 @@ export const session = sqliteTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     activeOrganizationId: text("active_organization_id"),
+    impersonatedBy: text("impersonated_by"),
   },
   (table) => [index("session_userId_idx").on(table.userId)],
 );

--- a/apps/idp/app/db/schema.ts
+++ b/apps/idp/app/db/schema.ts
@@ -23,7 +23,13 @@ export const applicationMember = sqliteTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     role: text("role", { enum: ["admin", "member"] }).notNull().default("member"),
+    // IdP-management permissions (what this principal may do *to the app in the
+    // IdP*). Distinct from productPermissions below.
     permissions: text("permissions", { mode: "json" }).$type<string[]>().default([]),
+    // The app's own product permissions, granted from the catalog the app
+    // declares in its metadata. Emitted downstream in the id_token; the app
+    // enforces them. Admins resolve to the full declared catalog.
+    productPermissions: text("product_permissions", { mode: "json" }).$type<string[]>().default([]),
     createdAt: integer("created_at", { mode: "timestamp" })
       .$defaultFn(() => new Date())
       .notNull(),
@@ -52,6 +58,8 @@ export const applicationInvitation = sqliteTable(
     email: text("email").notNull(),
     role: text("role", { enum: ["admin", "member"] }).notNull().default("member"),
     permissions: text("permissions", { mode: "json" }).$type<string[]>().default([]),
+    // Product-permission grants carried to the application_member row on accept.
+    productPermissions: text("product_permissions", { mode: "json" }).$type<string[]>().default([]),
     // Unguessable token for the branded accept link. Not the security boundary;
     // conversion is by verified-email match, the token only picks the landing UX.
     token: text("token").notNull().unique(),

--- a/apps/idp/app/lib/admin.server.ts
+++ b/apps/idp/app/lib/admin.server.ts
@@ -3,6 +3,7 @@ import { redirect } from "react-router"
 
 import * as schema from "../db/schema"
 import type { AuthService } from "./auth.server"
+import { type AppConfig, parseAppMetadata } from "./metadata"
 import type { BaseServiceContext } from "./services"
 
 function adminEmails(ctx: BaseServiceContext): string[] {
@@ -64,17 +65,12 @@ function coerceUriList(v: unknown): string[] {
   return Array.isArray(x) ? x.filter((s): s is string => typeof s === "string") : []
 }
 
-function coerceApp(v: unknown): string | null {
-  const x = unwrap(v)
-  return x && typeof x === "object" && typeof (x as { app?: unknown }).app === "string"
-    ? (x as { app: string }).app
-    : null
-}
-
 export type ApplicationSummary = {
   clientId: string
   name: string | null
   app: string | null
+  allowSignup: boolean
+  permissions: string[]
   redirectUris: string[]
   disabled: boolean
   createdAt: Date
@@ -93,14 +89,19 @@ export async function listApplications(ctx: BaseServiceContext): Promise<Applica
     .from(schema.oauthClient)
     .orderBy(desc(schema.oauthClient.createdAt))
 
-  return rows.map((r) => ({
-    clientId: r.clientId,
-    name: r.name,
-    app: coerceApp(r.metadata),
-    redirectUris: coerceUriList(r.redirectUris),
-    disabled: !!r.disabled,
-    createdAt: r.createdAt ?? new Date(0),
-  }))
+  return rows.map((r) => {
+    const meta = parseAppMetadata(unwrap(r.metadata))
+    return {
+      clientId: r.clientId,
+      name: r.name,
+      app: meta.app,
+      allowSignup: meta.allow_signup,
+      permissions: meta.permissions,
+      redirectUris: coerceUriList(r.redirectUris),
+      disabled: !!r.disabled,
+      createdAt: r.createdAt ?? new Date(0),
+    }
+  })
 }
 
 export async function getApplication(
@@ -109,6 +110,82 @@ export async function getApplication(
 ): Promise<ApplicationSummary | null> {
   const all = await listApplications(ctx)
   return all.find((a) => a.clientId === clientId) ?? null
+}
+
+/** Find an application by its app key (oauth_client.metadata.app). */
+export async function getApplicationByApp(
+  ctx: BaseServiceContext,
+  app: string,
+): Promise<ApplicationSummary | null> {
+  const all = await listApplications(ctx)
+  return all.find((a) => a.app === app) ?? null
+}
+
+/**
+ * Merge new product config into an app's metadata, preserving the immutable
+ * `app` key. Validated config only (allow_signup + declared permission catalog).
+ */
+export async function updateApplicationMetadata(
+  ctx: BaseServiceContext,
+  clientId: string,
+  config: AppConfig,
+) {
+  const [row] = await ctx.db
+    .select({ metadata: schema.oauthClient.metadata })
+    .from(schema.oauthClient)
+    .where(eq(schema.oauthClient.clientId, clientId))
+    .limit(1)
+  const app = parseAppMetadata(unwrap(row?.metadata)).app
+  await ctx.db
+    .update(schema.oauthClient)
+    .set({ metadata: { app, allow_signup: config.allow_signup, permissions: config.permissions } })
+    .where(eq(schema.oauthClient.clientId, clientId))
+}
+
+/** Per-app free-form metadata stored for one user. */
+export async function getUserAppMetadata(
+  ctx: BaseServiceContext,
+  app: string,
+  userId: string,
+): Promise<Record<string, unknown>> {
+  const [row] = await ctx.db
+    .select({ data: schema.userAppMetadata.data })
+    .from(schema.userAppMetadata)
+    .where(
+      and(
+        eq(schema.userAppMetadata.applicationId, app),
+        eq(schema.userAppMetadata.userId, userId),
+      ),
+    )
+    .limit(1)
+  return (unwrap(row?.data) as Record<string, unknown>) ?? {}
+}
+
+/** All per-user metadata rows for an app (for the member editor). */
+export async function listUserMetadataForApp(ctx: BaseServiceContext, app: string) {
+  const rows = await ctx.db
+    .select({ userId: schema.userAppMetadata.userId, data: schema.userAppMetadata.data })
+    .from(schema.userAppMetadata)
+    .where(eq(schema.userAppMetadata.applicationId, app))
+  return rows.map((r) => ({
+    userId: r.userId,
+    data: (unwrap(r.data) as Record<string, unknown>) ?? {},
+  }))
+}
+
+export async function setUserAppMetadata(
+  ctx: BaseServiceContext,
+  app: string,
+  userId: string,
+  data: Record<string, unknown>,
+) {
+  await ctx.db
+    .insert(schema.userAppMetadata)
+    .values({ applicationId: app, userId, data })
+    .onConflictDoUpdate({
+      target: [schema.userAppMetadata.applicationId, schema.userAppMetadata.userId],
+      set: { data, updatedAt: new Date() },
+    })
 }
 
 /**
@@ -152,6 +229,7 @@ export async function listAppMembers(ctx: BaseServiceContext, app: string) {
       name: schema.user.name,
       role: schema.applicationMember.role,
       permissions: schema.applicationMember.permissions,
+      productPermissions: schema.applicationMember.productPermissions,
     })
     .from(schema.applicationMember)
     .innerJoin(schema.user, eq(schema.applicationMember.userId, schema.user.id))

--- a/apps/idp/app/lib/auth.server.ts
+++ b/apps/idp/app/lib/auth.server.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm"
+import { and, eq, gt, isNotNull } from "drizzle-orm"
 import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import { admin } from "better-auth/plugins/admin"
@@ -11,6 +11,7 @@ import { Resend } from "resend"
 
 import * as schema from "../db/schema"
 import { claimInvitationsForUser } from "./members.server"
+import { parseAppMetadata } from "./metadata"
 import type { BaseServiceContext } from "./services"
 
 /**
@@ -32,6 +33,71 @@ function renderOtpEmail(baseUrl: string, email: string, otp: string) {
 }
 
 const WORKSPACES_CLAIM = "https://willy.im/workspaces"
+const PERMISSIONS_CLAIM = "https://willy.im/permissions"
+
+/**
+ * The caller's resolved *product* permissions for one app, read at token-mint
+ * (never from the client). Admins resolve to the app's full declared catalog;
+ * members to their granted product permissions (intersected with the catalog,
+ * in case the catalog shrank since the grant). App-scoped via metadata.app.
+ */
+async function productPermissionsFor(
+  db: BaseServiceContext["db"],
+  userId: string,
+  app: string | undefined,
+  catalog: string[],
+): Promise<string[]> {
+  if (!app) return []
+  const [member] = await db
+    .select({
+      role: schema.applicationMember.role,
+      productPermissions: schema.applicationMember.productPermissions,
+    })
+    .from(schema.applicationMember)
+    .where(
+      and(
+        eq(schema.applicationMember.applicationId, app),
+        eq(schema.applicationMember.userId, userId),
+      ),
+    )
+    .limit(1)
+  if (!member) return []
+  if (member.role === "admin") return catalog
+  const allowed = new Set(catalog)
+  return (member.productPermissions ?? []).filter((p) => allowed.has(p))
+}
+
+/**
+ * RFC 8693 `act` (actor) claim. If this user has an active impersonated session,
+ * the token is being minted on behalf of an admin acting as them — surface the
+ * admin so downstream apps can AUDIT it (they aren't expected to act on it). The
+ * claim hook has no session context, so we look up the live impersonated session
+ * by user; best-effort, audit-only.
+ */
+async function actClaimFor(
+  db: BaseServiceContext["db"],
+  userId: string,
+): Promise<{ sub: string; email?: string } | null> {
+  const [s] = await db
+    .select({ impersonatedBy: schema.session.impersonatedBy })
+    .from(schema.session)
+    .where(
+      and(
+        eq(schema.session.userId, userId),
+        isNotNull(schema.session.impersonatedBy),
+        gt(schema.session.expiresAt, new Date()),
+      ),
+    )
+    .limit(1)
+  const adminId = s?.impersonatedBy
+  if (!adminId) return null
+  const [admin] = await db
+    .select({ email: schema.user.email })
+    .from(schema.user)
+    .where(eq(schema.user.id, adminId))
+    .limit(1)
+  return { sub: adminId, ...(admin?.email ? { email: admin.email } : {}) }
+}
 
 /**
  * The workspaces (organizations) the user belongs to *within one application*,
@@ -176,9 +242,18 @@ export function createAuthService(context: BaseServiceContext) {
         // Each OAuth client is tagged with metadata.app (its application key).
         // We surface only that application's workspaces + roles as a claim.
         customIdTokenClaims: async ({ user, metadata }) => {
-          const app = (metadata as { app?: string } | undefined)?.app
-          const workspaces = await workspaceClaimsFor(context.db, user.id, app)
-          return workspaces.length ? { [WORKSPACES_CLAIM]: workspaces } : {}
+          const meta = parseAppMetadata(metadata)
+          const app = meta.app ?? undefined
+          const [workspaces, permissions, act] = await Promise.all([
+            workspaceClaimsFor(context.db, user.id, app),
+            productPermissionsFor(context.db, user.id, app, meta.permissions),
+            actClaimFor(context.db, user.id),
+          ])
+          return {
+            ...(workspaces.length ? { [WORKSPACES_CLAIM]: workspaces } : {}),
+            ...(permissions.length ? { [PERMISSIONS_CLAIM]: permissions } : {}),
+            ...(act ? { act } : {}),
+          }
         },
       }),
       // Impersonation. Only users with the `admin` role (= superadmin allowlist,

--- a/apps/idp/app/lib/auth.server.ts
+++ b/apps/idp/app/lib/auth.server.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm"
 import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
+import { admin } from "better-auth/plugins/admin"
 import { emailOTP } from "better-auth/plugins/email-otp"
 import { jwt } from "better-auth/plugins/jwt"
 import { organization } from "better-auth/plugins/organization"
@@ -56,6 +57,17 @@ export function createAuthService(context: BaseServiceContext) {
   const isProd = env.APP_ENV === "production"
   const url = new URL(env.BETTER_AUTH_URL)
 
+  // IdP-level superadmins (static allowlist). They — and only they — get the
+  // Better Auth `admin` role, which is what gates impersonation. App-scoped
+  // impersonation by app-admins is intentionally NOT enabled here: the admin
+  // plugin's authorization is global, so granting app-admins the role would let
+  // them call /auth/admin/impersonate-user directly and bypass app-scoping.
+  const superadminEmails = env.ADMIN_EMAILS.split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean)
+  const isSuperadminEmail = (email?: string | null) =>
+    !!email && superadminEmails.includes(email.toLowerCase())
+
   // In dev, trust common localhost ports so a default `npm run dev` (5173) works
   // even if BETTER_AUTH_URL points elsewhere. Prod trusts only its own origin.
   const trustedOrigins = isProd
@@ -83,11 +95,28 @@ export function createAuthService(context: BaseServiceContext) {
           after: async (session) => {
             try {
               const [u] = await context.db
-                .select({ id: schema.user.id, email: schema.user.email })
+                .select({ id: schema.user.id, email: schema.user.email, role: schema.user.role })
                 .from(schema.user)
                 .where(eq(schema.user.id, session.userId))
                 .limit(1)
-              if (u) await claimInvitationsForUser(context, u)
+              if (u) {
+                await claimInvitationsForUser(context, u)
+                // Keep the Better Auth admin role in sync with the superadmin
+                // allowlist — idempotent, so existing admins are backfilled on
+                // their next sign-in (and a removed email loses the role).
+                const shouldBeAdmin = isSuperadminEmail(u.email)
+                if (shouldBeAdmin && u.role !== "admin") {
+                  await context.db
+                    .update(schema.user)
+                    .set({ role: "admin" })
+                    .where(eq(schema.user.id, u.id))
+                } else if (!shouldBeAdmin && u.role === "admin") {
+                  await context.db
+                    .update(schema.user)
+                    .set({ role: null })
+                    .where(eq(schema.user.id, u.id))
+                }
+              }
             } catch (err) {
               context.logger.warn("invites.claim_failed", {
                 userId: session.userId,
@@ -152,6 +181,10 @@ export function createAuthService(context: BaseServiceContext) {
           return workspaces.length ? { [WORKSPACES_CLAIM]: workspaces } : {}
         },
       }),
+      // Impersonation. Only users with the `admin` role (= superadmin allowlist,
+      // synced above) may impersonate; impersonation sessions last 1h. App-scoped
+      // impersonation by app-admins is enforced in our own route, not here.
+      admin({ impersonationSessionDuration: 60 * 60 }),
     ],
   })
 }

--- a/apps/idp/app/lib/members.server.ts
+++ b/apps/idp/app/lib/members.server.ts
@@ -21,6 +21,21 @@ function sanitizePermissions(role: AppRole, permissions: string[]): AppPermissio
   )
 }
 
+/**
+ * Keep only product permissions the app actually declares (its `catalog`).
+ * Admins resolve to the full catalog downstream, so we don't store grants for
+ * them — the empty list keeps the column clean and unambiguous.
+ */
+function sanitizeProductPermissions(
+  role: AppRole,
+  productPermissions: string[],
+  catalog: string[],
+): string[] {
+  if (role === "admin") return []
+  const allowed = new Set(catalog)
+  return [...new Set(productPermissions)].filter((p) => allowed.has(p))
+}
+
 /** Look up a user by (normalized) email, or null. */
 export async function resolveUserByEmail(ctx: BaseServiceContext, email: string) {
   const [u] = await ctx.db
@@ -62,6 +77,9 @@ export async function addOrInviteAppMember(
     email: string
     role: AppRole
     permissions: string[]
+    // Product-permission grants + the app's declared catalog to validate against.
+    productPermissions?: string[]
+    catalog?: string[]
     // Null for machine callers (a scoped API key / superadmin token has no user).
     invitedByUserId: string | null
     origin: string
@@ -69,6 +87,11 @@ export async function addOrInviteAppMember(
 ): Promise<InviteResult> {
   const email = normalizeEmail(args.email)
   const permissions = sanitizePermissions(args.role, args.permissions)
+  const productPermissions = sanitizeProductPermissions(
+    args.role,
+    args.productPermissions ?? [],
+    args.catalog ?? [],
+  )
 
   const existing = await resolveUserByEmail(ctx, email)
   if (existing) {
@@ -89,6 +112,7 @@ export async function addOrInviteAppMember(
       userId: existing.id,
       role: args.role,
       permissions,
+      productPermissions,
     })
     return { kind: "added" }
   }
@@ -103,6 +127,7 @@ export async function addOrInviteAppMember(
       email,
       role: args.role,
       permissions,
+      productPermissions,
       token,
       invitedByUserId: args.invitedByUserId,
       expiresAt,
@@ -112,7 +137,7 @@ export async function addOrInviteAppMember(
         schema.applicationInvitation.applicationId,
         schema.applicationInvitation.email,
       ],
-      set: { role: args.role, permissions, token, expiresAt },
+      set: { role: args.role, permissions, productPermissions, token, expiresAt },
     })
 
   await sendInviteEmail(ctx, { origin: args.origin, email, token, app: args.app, role: args.role })
@@ -122,7 +147,14 @@ export async function addOrInviteAppMember(
 /** Update an existing member's role + permissions. Guards the last admin. */
 export async function updateAppMember(
   ctx: BaseServiceContext,
-  args: { app: string; userId: string; role: AppRole; permissions: string[] },
+  args: {
+    app: string
+    userId: string
+    role: AppRole
+    permissions: string[]
+    productPermissions?: string[]
+    catalog?: string[]
+  },
 ): Promise<{ ok: true } | { error: string }> {
   const [current] = await ctx.db
     .select({ role: schema.applicationMember.role })
@@ -143,7 +175,15 @@ export async function updateAppMember(
 
   await ctx.db
     .update(schema.applicationMember)
-    .set({ role: args.role, permissions: sanitizePermissions(args.role, args.permissions) })
+    .set({
+      role: args.role,
+      permissions: sanitizePermissions(args.role, args.permissions),
+      productPermissions: sanitizeProductPermissions(
+        args.role,
+        args.productPermissions ?? [],
+        args.catalog ?? [],
+      ),
+    })
     .where(
       and(
         eq(schema.applicationMember.applicationId, args.app),
@@ -288,6 +328,7 @@ export async function claimInvitationsForUser(
         userId: user.id,
         role: inv.role,
         permissions: inv.permissions ?? [],
+        productPermissions: inv.productPermissions ?? [],
       })
       .onConflictDoNothing()
     await ctx.db

--- a/apps/idp/app/lib/metadata.ts
+++ b/apps/idp/app/lib/metadata.ts
@@ -1,0 +1,48 @@
+import { z } from "zod"
+
+/**
+ * App + user metadata schemas. The app's metadata (stored on oauth_client) holds
+ * its product config: whether open signup is allowed and the catalog of product
+ * permissions it declares (which the IdP grants to members and emits downstream).
+ * User metadata is per-app free-form JSON the app cares about.
+ */
+
+const dedupe = (a: string[]) => [...new Set(a.map((s) => s.trim()).filter(Boolean))]
+
+/** Editable app config — the part an admin sets via the metadata editor. */
+export const appConfigSchema = z.object({
+  allow_signup: z.boolean().default(false),
+  // The app's declared product-permission catalog (unique, non-empty strings).
+  permissions: z.array(z.string().min(1)).default([]).transform(dedupe),
+})
+export type AppConfig = z.infer<typeof appConfigSchema>
+
+/** Full stored app metadata: the immutable `app` key plus the editable config. */
+export type AppMetadata = AppConfig & { app: string | null }
+
+/** Lenient read of whatever is stored in oauth_client.metadata. */
+export function parseAppMetadata(raw: unknown): AppMetadata {
+  const obj = (raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}) ?? {}
+  const app = typeof obj.app === "string" ? obj.app : null
+  const parsed = appConfigSchema.safeParse(obj)
+  const config = parsed.success ? parsed.data : { allow_signup: false, permissions: [] }
+  return { app, ...config }
+}
+
+/** Free-form per-app user metadata — any JSON object. */
+export const userMetadataSchema = z.record(z.string(), z.unknown())
+
+/** Parse + validate a JSON string the user typed into a metadata editor. */
+export function parseJsonObject(
+  raw: string,
+): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    return { ok: false, error: "Not valid JSON." }
+  }
+  const parsed = userMetadataSchema.safeParse(value)
+  if (!parsed.success) return { ok: false, error: "Metadata must be a JSON object." }
+  return { ok: true, value: parsed.data }
+}

--- a/apps/idp/app/routes.ts
+++ b/apps/idp/app/routes.ts
@@ -4,6 +4,7 @@ export default [
   route("login", "routes/login.tsx"),
   route("login/verify", "routes/login.verify.tsx"),
   route("invite/accept", "routes/invite.accept.tsx"),
+  route("impersonation/stop", "routes/impersonation.stop.ts"),
   route("consent", "routes/consent.tsx"),
   route("auth/*", "routes/auth/auth.$.ts"),
 

--- a/apps/idp/app/routes/app/account.tsx
+++ b/apps/idp/app/routes/app/account.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react"
-import { useNavigate } from "react-router"
+import { useState } from "react"
+import { useNavigate, useRevalidator } from "react-router"
 import { Fingerprint, Loader2, Plus, Trash2 } from "lucide-react"
 
 import type { Route } from "./+types/account"
@@ -13,29 +13,25 @@ export function meta() {
   return [{ title: "Account · willy.im" }]
 }
 
-export async function loader({ request, context }: Route.LoaderArgs) {
-  const session = await requireSession(request, context, context.services.auth)
-  return { user: { name: session.user.name, email: session.user.email } }
-}
-
 type Passkey = { id: string; name?: string | null }
 
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const session = await requireSession(request, context, context.services.auth)
+  // Server-rendered: passkeys come from the loader (session-authenticated), not a
+  // client fetch. Add/delete still run client-side (WebAuthn), then revalidate.
+  const passkeys = (await context.services.auth.api.listPasskeys({
+    headers: request.headers,
+  })) as Passkey[]
+  return { user: { name: session.user.name, email: session.user.email }, passkeys }
+}
+
 export default function Account({ loaderData }: Route.ComponentProps) {
-  const { user } = loaderData
+  const { user, passkeys } = loaderData
   const navigate = useNavigate()
+  const revalidator = useRevalidator()
   const [pending, setPending] = useState<null | "signout" | "add" | string>(null)
   const [error, setError] = useState<string | null>(null)
   const [name, setName] = useState("")
-  const [passkeys, setPasskeys] = useState<Passkey[] | null>(null)
-
-  async function refreshPasskeys() {
-    const { data } = await authClient.passkey.listUserPasskeys()
-    setPasskeys((data as Passkey[]) ?? [])
-  }
-
-  useEffect(() => {
-    refreshPasskeys()
-  }, [])
 
   async function signOut() {
     setPending("signout")
@@ -59,7 +55,7 @@ export default function Account({ loaderData }: Route.ComponentProps) {
         return
       }
       setName("")
-      await refreshPasskeys()
+      await revalidator.revalidate()
     } catch {
       // User dismissed the system prompt — nothing to report.
     } finally {
@@ -72,7 +68,7 @@ export default function Account({ loaderData }: Route.ComponentProps) {
     setPending(id)
     try {
       await authClient.passkey.deletePasskey({ id })
-      await refreshPasskeys()
+      await revalidator.revalidate()
     } finally {
       setPending(null)
     }
@@ -93,9 +89,7 @@ export default function Account({ loaderData }: Route.ComponentProps) {
           <CardDescription>Sign in without a code, using your device or password manager.</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
-          {passkeys === null ? (
-            <Loader2 className="text-muted-foreground size-4 animate-spin" />
-          ) : passkeys.length === 0 ? (
+          {passkeys.length === 0 ? (
             <p className="text-muted-foreground text-sm">No passkeys yet. Add one below.</p>
           ) : (
             <ul className="flex flex-col gap-1">

--- a/apps/idp/app/routes/app/app-detail.tsx
+++ b/apps/idp/app/routes/app/app-detail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Form, Link, redirect, useActionData, useNavigation, useSubmit } from "react-router"
-import { ChevronRight, KeyRound, Loader2, Mail, Plus, ScrollText, Terminal, Trash2, Users } from "lucide-react"
+import { ChevronRight, KeyRound, Loader2, Mail, Plus, ScrollText, Terminal, Trash2, UserCog, Users } from "lucide-react"
 
 import type { Route } from "./+types/app-detail"
 import {
@@ -98,6 +98,39 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       }
     await updateApplicationRedirectUris(request, auth, clientId, redirectUris)
     return { ok: "redirects" }
+  }
+
+  if (intent === "impersonate") {
+    const application = await getApplication(context, clientId)
+    const app = application?.app
+    if (!app) return { error: "This application has no app key yet." }
+    // Only superadmins can impersonate (the Better Auth admin role is
+    // superadmin-only — see auth.server.ts). We additionally scope the target to
+    // this app's members, so the action is app-bound and auditable.
+    const access = await requireAppPermission(request, context, auth, app, "user:impersonate")
+    if (!access.isSuperadmin) return { error: "Only superadmins can impersonate." }
+    const userId = String(form.get("userId") ?? "")
+    const appMembers = await listAppMembers(context, app)
+    const isMember = appMembers.find((m) => m.userId === userId)
+    if (!isMember) return { error: "That user isn't a member of this app." }
+
+    const res = await auth.api.impersonateUser({
+      body: { userId },
+      headers: request.headers,
+      asResponse: true,
+    })
+    await recordAudit(context, {
+      actor,
+      table: "user",
+      operation: "impersonate",
+      applicationId: app,
+      rowId: userId,
+      after: { email: isMember.email },
+    })
+    const headers = new Headers()
+    for (const cookie of res.headers.getSetCookie()) headers.append("set-cookie", cookie)
+    // Land on the impersonated user's account; a banner offers "stop".
+    return redirect("/account", { headers })
   }
 
   if (intent === "create-api-key" || intent === "revoke-api-key") {
@@ -873,6 +906,17 @@ function MemberRow({ member, busy }: { member: MemberRowData; busy: boolean }) {
           onClick={() => setEditing(true)}
         >
           Edit
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          title="Sign in as this user (superadmin only)"
+          onClick={() => submit({ intent: "impersonate", userId: member.userId }, { method: "post" })}
+        >
+          <UserCog className="size-3.5" />
+          Impersonate
         </Button>
         <AlertDialog>
           <AlertDialogTrigger

--- a/apps/idp/app/routes/app/app-detail.tsx
+++ b/apps/idp/app/routes/app/app-detail.tsx
@@ -9,11 +9,15 @@ import {
   getApplication,
   listAppMembers,
   listPeopleForApp,
+  listUserMetadataForApp,
   listWorkspacesForApp,
   requireAdminSession,
   rotateApplicationSecret,
+  setUserAppMetadata,
+  updateApplicationMetadata,
   updateApplicationRedirectUris,
 } from "~/lib/admin.server"
+import { appConfigSchema, parseJsonObject } from "~/lib/metadata"
 import {
   addOrInviteAppMember,
   listAppInvitations,
@@ -57,15 +61,16 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
   const application = await getApplication(context, params.clientId)
   if (!application) throw new Response("Application not found", { status: 404 })
   const app = application.app ?? ""
-  const [workspaces, people, members, invitations, apiKeys, audit] = await Promise.all([
+  const [workspaces, people, members, invitations, apiKeys, audit, userMetadata] = await Promise.all([
     app ? listWorkspacesForApp(context, app) : Promise.resolve([]),
     app ? listPeopleForApp(context, app) : Promise.resolve([]),
     app ? listAppMembers(context, app) : Promise.resolve([]),
     app ? listAppInvitations(context, app) : Promise.resolve([]),
     app ? listApiKeys(context, app) : Promise.resolve([]),
     app ? listAuditForApp(context, app, 20) : Promise.resolve([]),
+    app ? listUserMetadataForApp(context, app) : Promise.resolve([]),
   ])
-  return { application, workspaces, people, members, invitations, apiKeys, audit }
+  return { application, workspaces, people, members, invitations, apiKeys, audit, userMetadata }
 }
 
 export async function action({ request, context, params }: Route.ActionArgs) {
@@ -218,10 +223,13 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     if (!app) return { error: "This application has no app key yet." }
     const origin = new URL(request.url).origin
 
+    const catalog = application?.permissions ?? []
     const readRole = (v: FormDataEntryValue | null): AppRole =>
       String(v) === "admin" ? "admin" : "member"
     const readPermissions = () =>
       form.getAll("permissions").map(String).filter(Boolean)
+    const readProductPermissions = () =>
+      form.getAll("productPermissions").map(String).filter(Boolean)
 
     if (intent === "invite-member") {
       const access = await requireAppPermission(request, context, auth, app, "member:invite")
@@ -233,6 +241,8 @@ export async function action({ request, context, params }: Route.ActionArgs) {
         email,
         role: readRole(form.get("role")),
         permissions: readPermissions(),
+        productPermissions: readProductPermissions(),
+        catalog,
         invitedByUserId: access.user.id,
         origin,
       })
@@ -257,6 +267,8 @@ export async function action({ request, context, params }: Route.ActionArgs) {
         userId,
         role,
         permissions: readPermissions(),
+        productPermissions: readProductPermissions(),
+        catalog,
       })
       if ("error" in res) return { error: res.error }
       await recordAudit(context, {
@@ -265,7 +277,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
         operation: "update",
         applicationId: app,
         rowId: userId,
-        after: { role, permissions: readPermissions() },
+        after: { role, permissions: readPermissions(), productPermissions: readProductPermissions() },
       })
       return { ok: "member-updated" }
     }
@@ -302,11 +314,54 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     }
   }
 
+  if (intent === "update-app-metadata") {
+    const application = await getApplication(context, clientId)
+    const app = application?.app
+    if (!app) return { error: "This application has no app key yet." }
+    await requireAppPermission(request, context, auth, app, "app:update")
+    const parsed = appConfigSchema.safeParse({
+      allow_signup: form.get("allow_signup") === "on",
+      permissions: parseUriList(String(form.get("permissions") ?? "")),
+    })
+    if (!parsed.success) return { error: "Invalid app settings.", field: "app-metadata" }
+    await updateApplicationMetadata(context, clientId, parsed.data)
+    await recordAudit(context, {
+      actor,
+      table: "oauth_client",
+      operation: "update",
+      applicationId: app,
+      after: parsed.data,
+    })
+    return { ok: "app-metadata" }
+  }
+
+  if (intent === "set-user-metadata") {
+    const application = await getApplication(context, clientId)
+    const app = application?.app
+    if (!app) return { error: "This application has no app key yet." }
+    await requireAppPermission(request, context, auth, app, "member:manage")
+    const userId = String(form.get("userId") ?? "")
+    const parsed = parseJsonObject(String(form.get("metadata") ?? "{}"))
+    if (!parsed.ok) return { error: parsed.error, field: `user-meta-${userId}` }
+    await setUserAppMetadata(context, app, userId, parsed.value)
+    await recordAudit(context, {
+      actor,
+      table: "user_app_metadata",
+      operation: "update",
+      applicationId: app,
+      rowId: userId,
+    })
+    return { ok: "user-metadata" }
+  }
+
   return { error: "Unknown action" }
 }
 
 export default function AppDetail({ loaderData }: Route.ComponentProps) {
-  const { application, workspaces, people, members, invitations, apiKeys, audit } = loaderData
+  const { application, workspaces, people, members, invitations, apiKeys, audit, userMetadata } =
+    loaderData
+  const catalog = application.permissions
+  const metaByUser = new Map(userMetadata.map((m) => [m.userId, m.data]))
   const actionData = useActionData<typeof action>()
   const nav = useNavigation()
   const submit = useSubmit()
@@ -457,6 +512,56 @@ export default function AppDetail({ loaderData }: Route.ComponentProps) {
         </CardContent>
       </Card>
 
+      {/* App settings — product config stored in the app's metadata */}
+      <Card>
+        <CardHeader>
+          <CardTitle>App settings</CardTitle>
+          <CardDescription>
+            Product config the app declares. <code>allow_signup</code> gates open vs invite-only;
+            the permission catalog is what members can be granted and what's emitted downstream.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form method="post" className="flex flex-col gap-4">
+            <input type="hidden" name="intent" value="update-app-metadata" />
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                name="allow_signup"
+                defaultChecked={application.allowSignup}
+                disabled={busy}
+                className="size-4"
+              />
+              Allow open signup (otherwise invite-only)
+            </label>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="app-permissions">Product permission catalog</Label>
+              <textarea
+                id="app-permissions"
+                name="permissions"
+                rows={4}
+                defaultValue={application.permissions.join("\n")}
+                placeholder={"posts:read\nposts:write\nbilling:manage"}
+                disabled={busy}
+                className="border-input bg-transparent placeholder:text-muted-foreground focus-visible:ring-ring/50 min-h-16 w-full rounded-md border px-3 py-2 font-mono text-xs shadow-xs focus-visible:ring-[3px] focus-visible:outline-none"
+              />
+              <p className="text-muted-foreground text-xs">
+                One permission per line. Duplicates are removed.
+              </p>
+            </div>
+            {field === "app-metadata" && error ? (
+              <p role="alert" className="text-destructive text-sm">
+                {error}
+              </p>
+            ) : null}
+            <Button type="submit" variant="outline" disabled={busy} className="self-start">
+              {busy ? <Loader2 className="size-4 animate-spin" /> : null}
+              Save app settings
+            </Button>
+          </Form>
+        </CardContent>
+      </Card>
+
       {/* App access — admins & members (IdP-level) */}
       <Card>
         <CardHeader>
@@ -470,7 +575,11 @@ export default function AppDetail({ loaderData }: Route.ComponentProps) {
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-6">
-          <InviteMemberForm busy={busy} error={field === "invite-email" ? (error ?? null) : null} />
+          <InviteMemberForm
+            busy={busy}
+            error={field === "invite-email" ? (error ?? null) : null}
+            catalog={catalog}
+          />
 
           {memberError && field !== "invite-email" ? (
             <p role="alert" className="text-destructive text-sm">
@@ -492,7 +601,13 @@ export default function AppDetail({ loaderData }: Route.ComponentProps) {
               </TableHeader>
               <TableBody>
                 {members.map((m) => (
-                  <MemberRow key={m.userId} member={m} busy={busy} />
+                  <MemberRow
+                    key={m.userId}
+                    member={m}
+                    busy={busy}
+                    catalog={catalog}
+                    userMetadata={metaByUser.get(m.userId) ?? {}}
+                  />
                 ))}
               </TableBody>
             </Table>
@@ -740,21 +855,27 @@ export default function AppDetail({ loaderData }: Route.ComponentProps) {
 const selectClass =
   "border-input bg-transparent focus-visible:ring-ring/50 h-8 rounded-md border px-2 text-sm shadow-xs focus-visible:ring-[3px] focus-visible:outline-none"
 
-/** Checkboxes for the IdP management permission catalog (members only). */
+/** Checkboxes for a permission catalog. `name` is the form field the values post under. */
 function PermissionPicker({
+  name,
+  options,
   selected,
   disabled,
 }: {
+  name: string
+  options: readonly string[]
   selected: string[]
   disabled?: boolean
 }) {
+  if (options.length === 0)
+    return <p className="text-muted-foreground text-xs">No permissions declared.</p>
   return (
     <fieldset className="grid grid-cols-2 gap-x-4 gap-y-1.5 sm:grid-cols-3">
-      {APP_PERMISSIONS.map((p) => (
+      {options.map((p) => (
         <label key={p} className="flex items-center gap-2 text-xs">
           <input
             type="checkbox"
-            name="permissions"
+            name={name}
             value={p}
             defaultChecked={selected.includes(p)}
             disabled={disabled}
@@ -768,7 +889,15 @@ function PermissionPicker({
 }
 
 /** Invite by email: existing user → added now; new email → invitation sent. */
-function InviteMemberForm({ busy, error }: { busy: boolean; error: string | null }) {
+function InviteMemberForm({
+  busy,
+  error,
+  catalog,
+}: {
+  busy: boolean
+  error: string | null
+  catalog: string[]
+}) {
   const [role, setRole] = useState<AppRole>("member")
   return (
     <Form method="post" className="flex flex-col gap-3 rounded-lg border p-4">
@@ -806,9 +935,15 @@ function InviteMemberForm({ busy, error }: { busy: boolean; error: string | null
         </Button>
       </div>
       {role === "member" ? (
-        <div className="flex flex-col gap-1.5">
-          <Label className="text-muted-foreground text-xs">Permissions</Label>
-          <PermissionPicker selected={[]} disabled={busy} />
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-muted-foreground text-xs">IdP management permissions</Label>
+            <PermissionPicker name="permissions" options={APP_PERMISSIONS} selected={[]} disabled={busy} />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-muted-foreground text-xs">Product permissions</Label>
+            <PermissionPicker name="productPermissions" options={catalog} selected={[]} disabled={busy} />
+          </div>
         </div>
       ) : (
         <p className="text-muted-foreground text-xs">Admins get all permissions.</p>
@@ -828,10 +963,21 @@ type MemberRowData = {
   name: string | null
   role: "admin" | "member"
   permissions: string[] | null
+  productPermissions: string[] | null
 }
 
-/** A member row, collapsible into an inline role + permission editor. */
-function MemberRow({ member, busy }: { member: MemberRowData; busy: boolean }) {
+/** A member row, collapsible into an inline role + permission + metadata editor. */
+function MemberRow({
+  member,
+  busy,
+  catalog,
+  userMetadata,
+}: {
+  member: MemberRowData
+  busy: boolean
+  catalog: string[]
+  userMetadata: Record<string, unknown>
+}) {
   const submit = useSubmit()
   const [editing, setEditing] = useState(false)
   const [role, setRole] = useState<AppRole>(member.role)
@@ -861,7 +1007,26 @@ function MemberRow({ member, busy }: { member: MemberRowData; busy: boolean }) {
               </select>
             </div>
             {role === "member" ? (
-              <PermissionPicker selected={member.permissions ?? []} disabled={busy} />
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1.5">
+                  <Label className="text-muted-foreground text-xs">IdP management permissions</Label>
+                  <PermissionPicker
+                    name="permissions"
+                    options={APP_PERMISSIONS}
+                    selected={member.permissions ?? []}
+                    disabled={busy}
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label className="text-muted-foreground text-xs">Product permissions</Label>
+                  <PermissionPicker
+                    name="productPermissions"
+                    options={catalog}
+                    selected={member.productPermissions ?? []}
+                    disabled={busy}
+                  />
+                </div>
+              </div>
             ) : (
               <p className="text-muted-foreground text-xs">Admins get all permissions.</p>
             )}
@@ -882,6 +1047,26 @@ function MemberRow({ member, busy }: { member: MemberRowData; busy: boolean }) {
                 Cancel
               </Button>
             </div>
+          </Form>
+
+          {/* Per-app user metadata — free-form JSON */}
+          <Form method="post" className="mt-3 flex flex-col gap-1.5 border-t pt-3">
+            <input type="hidden" name="intent" value="set-user-metadata" />
+            <input type="hidden" name="userId" value={member.userId} />
+            <Label htmlFor={`meta-${member.userId}`} className="text-muted-foreground text-xs">
+              User metadata (JSON, for this app)
+            </Label>
+            <textarea
+              id={`meta-${member.userId}`}
+              name="metadata"
+              rows={3}
+              defaultValue={JSON.stringify(userMetadata, null, 2)}
+              disabled={busy}
+              className="border-input bg-transparent focus-visible:ring-ring/50 min-h-16 w-full rounded-md border px-3 py-2 font-mono text-xs shadow-xs focus-visible:ring-[3px] focus-visible:outline-none"
+            />
+            <Button type="submit" size="sm" variant="outline" disabled={busy} className="self-start">
+              Save metadata
+            </Button>
           </Form>
         </TableCell>
       </TableRow>
@@ -996,7 +1181,12 @@ function CreateApiKeyForm({
       </div>
       <div className="flex flex-col gap-1.5">
         <Label className="text-muted-foreground text-xs">Permissions</Label>
-        <PermissionPicker selected={[]} disabled={busy || disabled} />
+        <PermissionPicker
+          name="permissions"
+          options={APP_PERMISSIONS}
+          selected={[]}
+          disabled={busy || disabled}
+        />
       </div>
       {error ? (
         <p role="alert" className="text-destructive text-sm">

--- a/apps/idp/app/routes/app/layout.tsx
+++ b/apps/idp/app/routes/app/layout.tsx
@@ -1,5 +1,5 @@
-import { Link, Outlet, useLocation, useNavigate } from "react-router"
-import { ShieldCheck } from "lucide-react"
+import { Form, Link, Outlet, useLocation, useNavigate } from "react-router"
+import { ShieldCheck, UserCog } from "lucide-react"
 
 import type { Route } from "./+types/layout"
 import { isAdminEmail, requireSession } from "~/lib/admin.server"
@@ -7,11 +7,16 @@ import { cn } from "~/lib/utils"
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const session = await requireSession(request, context, context.services.auth)
-  return { email: session.user.email, isAdmin: isAdminEmail(context, session.user.email) }
+  return {
+    email: session.user.email,
+    isAdmin: isAdminEmail(context, session.user.email),
+    // Set on impersonation sessions (Better Auth admin plugin).
+    impersonating: !!session.session.impersonatedBy,
+  }
 }
 
 export default function ConsoleLayout({ loaderData }: Route.ComponentProps) {
-  const { email, isAdmin } = loaderData
+  const { email, isAdmin, impersonating } = loaderData
   const { pathname } = useLocation()
   const navigate = useNavigate()
 
@@ -27,6 +32,22 @@ export default function ConsoleLayout({ loaderData }: Route.ComponentProps) {
 
   return (
     <div className="mx-auto flex min-h-dvh w-full max-w-4xl flex-col gap-6 p-6">
+      {impersonating ? (
+        <div className="bg-amber-500/15 text-amber-700 dark:text-amber-400 flex flex-wrap items-center justify-between gap-2 rounded-md border border-amber-500/40 px-3 py-2 text-sm">
+          <span className="flex items-center gap-2">
+            <UserCog className="size-4" />
+            Impersonating <span className="font-medium">{email}</span> — actions run as this user.
+          </span>
+          <Form method="post" action="/impersonation/stop">
+            <button
+              type="submit"
+              className="rounded-md border border-amber-500/50 px-2 py-1 text-xs font-medium hover:bg-amber-500/20"
+            >
+              Stop impersonating
+            </button>
+          </Form>
+        </div>
+      ) : null}
       <header className="flex items-center justify-between">
         <Link to="/" className="flex items-center gap-2 no-underline">
           <ShieldCheck className="text-primary size-5" />

--- a/apps/idp/app/routes/impersonation.stop.ts
+++ b/apps/idp/app/routes/impersonation.stop.ts
@@ -1,0 +1,25 @@
+import { redirect } from "react-router"
+
+import type { Route } from "./+types/impersonation.stop"
+
+/**
+ * Ends an impersonation session and restores the original admin session. Better
+ * Auth swaps the session cookie back (it stashed the admin session token in an
+ * `admin_session` cookie when impersonation started), so we forward its
+ * Set-Cookie headers on the redirect.
+ */
+export async function action({ request, context }: Route.ActionArgs) {
+  const auth = context.services.auth
+  const res = await auth.api.stopImpersonating({
+    headers: request.headers,
+    asResponse: true,
+  })
+  const headers = new Headers()
+  for (const cookie of res.headers.getSetCookie()) headers.append("set-cookie", cookie)
+  return redirect("/", { headers })
+}
+
+// Reaching this route with GET just bounces home.
+export async function loader() {
+  return redirect("/")
+}

--- a/apps/idp/drizzle/0008_omniscient_joshua_kane.sql
+++ b/apps/idp/drizzle/0008_omniscient_joshua_kane.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `session` ADD `impersonated_by` text;--> statement-breakpoint
+ALTER TABLE `user` ADD `role` text;--> statement-breakpoint
+ALTER TABLE `user` ADD `banned` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `user` ADD `ban_reason` text;--> statement-breakpoint
+ALTER TABLE `user` ADD `ban_expires` integer;

--- a/apps/idp/drizzle/0009_amusing_garia.sql
+++ b/apps/idp/drizzle/0009_amusing_garia.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `application_invitation` ADD `product_permissions` text DEFAULT '[]';--> statement-breakpoint
+ALTER TABLE `application_member` ADD `product_permissions` text DEFAULT '[]';

--- a/apps/idp/drizzle/meta/0008_snapshot.json
+++ b/apps/idp/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,2024 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b3b613ab-f4eb-49b5-be17-6389d00118c9",
+  "prevId": "e8de0d78-49a1-4a75-b250-f66fb843c791",
+  "tables": {
+    "api_key": {
+      "name": "api_key",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "api_key_app_idx": {
+          "name": "api_key_app_idx",
+          "columns": [
+            "application_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_meta": {
+      "name": "app_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_invitation": {
+      "name": "application_invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_invitation_token_unique": {
+          "name": "application_invitation_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "application_invitation_app_email_uidx": {
+          "name": "application_invitation_app_email_uidx",
+          "columns": [
+            "application_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_invitation_invited_by_user_id_user_id_fk": {
+          "name": "application_invitation_invited_by_user_id_user_id_fk",
+          "tableFrom": "application_invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_member": {
+      "name": "application_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_member_app_user_uidx": {
+          "name": "application_member_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_member_user_id_user_id_fk": {
+          "name": "application_member_user_id_user_id_fk",
+          "tableFrom": "application_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_data": {
+          "name": "old_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_data": {
+          "name": "new_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "audit_logs_application_id_idx": {
+          "name": "audit_logs_application_id_idx",
+          "columns": [
+            "application_id"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_table_name_idx": {
+          "name": "audit_logs_table_name_idx",
+          "columns": [
+            "table_name"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_app_metadata": {
+      "name": "user_app_metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_app_metadata_app_user_uidx": {
+          "name": "user_app_metadata_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_app_metadata_user_id_user_id_fk": {
+          "name": "user_app_metadata_user_id_user_id_fk",
+          "tableFrom": "user_app_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_token": {
+      "name": "oauth_access_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consent": {
+      "name": "oauth_consent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/idp/drizzle/meta/0009_snapshot.json
+++ b/apps/idp/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,2040 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4097fc4c-374e-4c13-8c81-743295cc5979",
+  "prevId": "b3b613ab-f4eb-49b5-be17-6389d00118c9",
+  "tables": {
+    "api_key": {
+      "name": "api_key",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "api_key_app_idx": {
+          "name": "api_key_app_idx",
+          "columns": [
+            "application_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_meta": {
+      "name": "app_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_invitation": {
+      "name": "application_invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "product_permissions": {
+          "name": "product_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_invitation_token_unique": {
+          "name": "application_invitation_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "application_invitation_app_email_uidx": {
+          "name": "application_invitation_app_email_uidx",
+          "columns": [
+            "application_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_invitation_invited_by_user_id_user_id_fk": {
+          "name": "application_invitation_invited_by_user_id_user_id_fk",
+          "tableFrom": "application_invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "application_member": {
+      "name": "application_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "product_permissions": {
+          "name": "product_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "application_member_app_user_uidx": {
+          "name": "application_member_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "application_member_user_id_user_id_fk": {
+          "name": "application_member_user_id_user_id_fk",
+          "tableFrom": "application_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_data": {
+          "name": "old_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_data": {
+          "name": "new_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "audit_logs_application_id_idx": {
+          "name": "audit_logs_application_id_idx",
+          "columns": [
+            "application_id"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_table_name_idx": {
+          "name": "audit_logs_table_name_idx",
+          "columns": [
+            "table_name"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_app_metadata": {
+      "name": "user_app_metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_app_metadata_app_user_uidx": {
+          "name": "user_app_metadata_app_user_uidx",
+          "columns": [
+            "application_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_app_metadata_user_id_user_id_fk": {
+          "name": "user_app_metadata_user_id_user_id_fk",
+          "tableFrom": "user_app_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_token": {
+      "name": "oauth_access_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consent": {
+      "name": "oauth_consent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/idp/drizzle/meta/_journal.json
+++ b/apps/idp/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781068092007,
       "tag": "0008_omniscient_joshua_kane",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1781145424467,
+      "tag": "0009_amusing_garia",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/idp/drizzle/meta/_journal.json
+++ b/apps/idp/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1781067648157,
       "tag": "0007_exotic_living_tribunal",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1781068092007,
+      "tag": "0008_omniscient_joshua_kane",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/idp/scripts/auth.gen.ts
+++ b/apps/idp/scripts/auth.gen.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
+import { admin } from "better-auth/plugins/admin"
 import { emailOTP } from "better-auth/plugins/email-otp"
 import { jwt } from "better-auth/plugins/jwt"
 import { organization } from "better-auth/plugins/organization"
@@ -33,5 +34,7 @@ export const auth = betterAuth({
     }),
     jwt(),
     oauthProvider({ loginPage: "/login", consentPage: "/consent", storeClientSecret: "hashed" }),
+    // Impersonation (+ role/ban columns). Superadmin-scoped; see auth.server.ts.
+    admin(),
   ],
 })


### PR DESCRIPTION
Part of #33 — **Next: programmatic + safety → Impersonation** ("Better Auth `admin` plugin; scoped + audited"). Stacked on #40.

Lets a superadmin sign in *as* an app's user to debug their experience, with the action recorded in the audit trail and a persistent banner offering one-click exit.

### Authorization model (why superadmin-only, for now)
Adding the Better Auth `admin` plugin exposes `POST /auth/admin/impersonate-user`, authorized by a **global** role check (`user:impersonate`). Our model is per-app: an app-admin should impersonate only *their* app's users. A global role can't express that — and if app-admins were given the role, they could hit the raw endpoint and impersonate *anyone*, bypassing app-scoping.

So this PR enables **superadmin-only** impersonation: only the `ADMIN_EMAILS` allowlist gets the `admin` role (synced idempotently on sign-in; a removed email loses it). Our own route additionally requires the target to be a **member of the app**, giving an app-scoped, auditable action. Full app-admin-scoped impersonation is a documented follow-up (needs a custom access-control config so the raw endpoint stays superadmin-only while app-admins go through our scoped route).

### What's in here
- **Admin plugin + migration `0008`** — additive columns only: `user.role` / `banned` / `ban_reason` / `ban_expires`, `session.impersonated_by`. Schema regenerated via `npm run auth:db:generate`; `scripts/auth.gen.ts` mirror updated.
- **Impersonate** — an action on each member row: superadmin gate → target must be an app member → `impersonateUser` (Set-Cookie forwarded on a redirect to `/account`) → an `impersonate` audit entry (via the audit log from #40).
- **Stop** — an amber "Impersonating <user>" banner in the console layout with a Stop button (`/impersonation/stop` → `stopImpersonating` restores the original admin session). 1h impersonation sessions.

### Validation
- `npm run typecheck` passes.

### Verification gap (please sanity-check on a branch deploy)
The impersonate ⇄ stop **cookie swap** is the one path I couldn't exercise end-to-end locally (no running auth env). The schema/role changes are additive and don't affect normal sign-in; the flow itself is isolated. Worth a quick manual check before merge.