### PR TITLE
feat(drizzle-audit): ambient audit context via AsyncLocalStorage (0.6.0)

### DIFF
--- a/packages/drizzle_audit/README.md
+++ b/packages/drizzle_audit/README.md
@@ -179,6 +179,60 @@ withD1AuditedTransaction(db, "user_1", (tx) => { /* ... */ }, {
 })
 ```
 
+## Ambient Context (AsyncLocalStorage)
+
+The explicit `withAuditedTransaction(db, actorId, cb)` is the cross-runtime floor —
+it works everywhere and you pass the actor by hand. The opt-in
+`@willyim/drizzle-audit/context` export adds an *ambient* layer on top: establish
+"who is acting" **once** at an entry boundary (a request, a job, an engine tick),
+then open-or-reuse a single audited transaction anywhere below — the actor is read
+from the ambient store, never threaded through call signatures.
+
+```ts
+import {
+  runWithAuditContext,
+  ensureAuditedTx,
+  currentAudit,
+} from "@willyim/drizzle-audit/context"
+
+// 1. Boundary: set the ambient actor for the unit of work. Pass a thunk to
+//    resolve it LAZILY — it only runs if a write actually happens, so read-only
+//    requests never pay for it (e.g. resolving a session).
+app.use((req, next) =>
+  runWithAuditContext(
+    async () => ({
+      actorId: (await getSession(req)).userId,
+      context: { "app.workspace_id": req.workspaceId },
+    }),
+    next,
+  ),
+)
+
+// 2. Anywhere below: open-or-reuse ONE audited tx. Reads don't call this, so
+//    they never open a transaction. Reentrant — nested calls share the tx.
+async function archive(db, id) {
+  await ensureAuditedTx(db, async (tx) => {
+    await tx.update(items).set({ archived: true }).where(eq(items.id, id))
+  })
+}
+
+// 3. Read the actor for a domain column (inside the callback, where it's resolved).
+async function assign(db, id, to) {
+  await ensureAuditedTx(db, async (tx) => {
+    await tx.insert(assignments).values({ id, to, assignedBy: currentAudit().actorId })
+  })
+}
+```
+
+**Runtime support.** This uses *only* `AsyncLocalStorage` from `node:async_hooks`
+(not `createHook`/`executionAsyncId`/…), which is the subset Cloudflare Workers
+implements. Works on Node, Bun, and Workers — Workers needs the `nodejs_compat`
+flag and a recent compatibility date. If a target lacks ALS, the import throws
+loudly; fall back to the explicit `withAuditedTransaction`.
+
+**Guardrail.** `ensureAuditedTx` (and `currentAudit`) throw if there is no ambient
+context — a missed boundary becomes a loud failure instead of an unattributed write.
+
 ## CLI
 
 Generate a Drizzle migration with audit SQL appended:
@@ -220,6 +274,18 @@ export function createAuditSql() {
 | `createAuditAddContextColumnsSql(options)` | SQL to add context columns + regenerate trigger on existing install |
 | `setAuditContext(db, actorId, contextKey?, options?)` | Set actor context in current transaction |
 | `withAuditedTransaction(db, actorId, callback, contextKey?, options?)` | Transaction wrapper with actor context |
+
+### `@willyim/drizzle-audit/context`
+
+Opt-in ambient layer (AsyncLocalStorage). See [Ambient Context](#ambient-context-asynclocalstorage).
+
+| Export | Description |
+|---|---|
+| `runWithAuditContext(audit, fn)` | Set the ambient actor for `fn` (`audit` is an `AuditContext` or a lazy thunk) |
+| `ensureAuditedTx(db, run, contextKey?)` | Open-or-reuse one audited tx; actor read from the ambient context |
+| `currentAudit()` | The resolved ambient `AuditContext` (throws if absent/unresolved) |
+| `maybeCurrentAudit()` | The resolved ambient `AuditContext`, or `null` |
+| `hasAuditContext()` | Whether an ambient context is in scope |
 
 ### `@willyim/drizzle-audit`
 

--- a/packages/drizzle_audit/package.json
+++ b/packages/drizzle_audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-audit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Lightweight audit logging for Drizzle ORM using database triggers (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./postgres": "./dist/src/postgres/index.js",
+    "./context": "./dist/src/context/index.js",
     "./d1": "./dist/src/d1/index.js",
     "./d1-runtime": "./dist/src/d1-runtime/index.js"
   },

--- a/packages/drizzle_audit/src/context/index.ts
+++ b/packages/drizzle_audit/src/context/index.ts
@@ -1,0 +1,152 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
+import { setAuditContext } from "../postgres/runtime.js"
+import type {
+  AuditSqlExecutor,
+  AuditTransactionCapable,
+} from "../postgres/types.js"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ambient audit context (opt-in).
+//
+// The explicit `withAuditedTransaction(db, actorId, cb)` from the main entry is
+// the cross-runtime floor: it works everywhere and takes the actor by hand. This
+// module adds an *ambient* layer on top of it, built on `AsyncLocalStorage`:
+//
+//   - establish "who is acting" ONCE at an entry boundary (a request, a job, an
+//     engine tick) with `runWithAuditContext`, then
+//   - open-or-reuse a single audited transaction anywhere below with
+//     `ensureAuditedTx` — the actor is read from the ambient store, never
+//     threaded through call signatures.
+//
+// Runtime support: this uses ONLY `AsyncLocalStorage` from `node:async_hooks`
+// (not `createHook`/`executionAsyncId`/…), which is the subset Cloudflare
+// Workers implements. It works on Node, Bun, and Workers (Workers needs the
+// `nodejs_compat` flag + a recent compatibility date). If a target lacks ALS,
+// fall back to the explicit `withAuditedTransaction` path.
+// ─────────────────────────────────────────────────────────────────────────────
+
+if (typeof AsyncLocalStorage === "undefined") {
+  throw new Error(
+    "@willyim/drizzle-audit/context requires AsyncLocalStorage from node:async_hooks. " +
+      "On Cloudflare Workers enable the `nodejs_compat` flag (with a recent compatibility " +
+      "date). On other runtimes use the explicit withAuditedTransaction(db, actorId, cb) " +
+      "from @willyim/drizzle-audit/postgres instead.",
+  )
+}
+
+/** Opaque to the library: an actor string + the GUC map written for the tx. */
+export type AuditContext = {
+  /** Value written to the actor GUC (default `app.user_id`). */
+  actorId: string
+  /** Extra session GUCs (full GUC name → value), e.g. `app.workspace_id`. */
+  context?: Record<string, string>
+}
+
+/**
+ * How the ambient actor is resolved. Pass a plain `AuditContext` to resolve it
+ * eagerly, or a thunk to resolve it LAZILY — the thunk runs only when the first
+ * audited write actually happens, so read-only units of work never pay for it
+ * (e.g. resolving a session on a request that only reads).
+ */
+export type AuditContextInput =
+  | AuditContext
+  | (() => AuditContext | Promise<AuditContext>)
+
+type Cell = {
+  resolve: () => AuditContext | Promise<AuditContext>
+  /** Memoised result of `resolve` once it has run. */
+  resolved: AuditContext | null
+  /** The currently-open audited tx, tracked for reentrancy. */
+  tx: AuditSqlExecutor | null
+}
+
+const als = new AsyncLocalStorage<Cell>()
+
+/**
+ * Establish the ambient audit actor for the duration of `fn`. No transaction is
+ * opened here — `ensureAuditedTx` opens one lazily on the first write below.
+ */
+export function runWithAuditContext<T>(
+  audit: AuditContextInput,
+  fn: () => T,
+): T {
+  const resolve = typeof audit === "function" ? audit : () => audit
+  const resolved = typeof audit === "function" ? null : audit
+  return als.run({ resolve, resolved, tx: null }, fn)
+}
+
+/** The ambient audit context if one is set AND already resolved, else null. */
+export function maybeCurrentAudit(): AuditContext | null {
+  return als.getStore()?.resolved ?? null
+}
+
+/**
+ * The ambient audit context. Throws if no context is set, or if it is set but
+ * not yet resolved (a lazy resolver that has not run). It is always resolved
+ * inside an `ensureAuditedTx` callback, which is the intended place to read it
+ * (e.g. to stamp a domain "createdBy" column from the actor).
+ */
+export function currentAudit(): AuditContext {
+  const cell = als.getStore()
+  if (!cell) {
+    throw new Error(
+      "no ambient audit context — wrap the unit of work in runWithAuditContext(...)",
+    )
+  }
+  if (!cell.resolved) {
+    throw new Error(
+      "ambient audit context not resolved yet — read currentAudit() inside an " +
+        "ensureAuditedTx callback, or pass an eager AuditContext to runWithAuditContext",
+    )
+  }
+  return cell.resolved
+}
+
+/** True if an ambient audit context is in scope (resolved or not). */
+export function hasAuditContext(): boolean {
+  return als.getStore() !== undefined
+}
+
+/**
+ * THE primitive: ensure this unit of work runs inside ONE audited transaction,
+ * reusing an already-open one if present (reentrant). The actor is read from the
+ * ambient context (resolving it on first use). Reads should never call this, so
+ * they never open a transaction.
+ *
+ * Throws if called with no ambient audit context — the guardrail that turns a
+ * missed boundary into a loud failure instead of an unattributed write.
+ */
+export async function ensureAuditedTx<
+  TTransaction extends AuditSqlExecutor,
+  TResult,
+>(
+  db: AuditTransactionCapable<TTransaction>,
+  run: (tx: TTransaction) => Promise<TResult> | TResult,
+  contextKey = "app.user_id",
+): Promise<TResult> {
+  const cell = als.getStore()
+  if (!cell) {
+    throw new Error(
+      "audited write outside an audit context — wrap the unit of work in " +
+        "runWithAuditContext(...) (or use the explicit withAuditedTransaction)",
+    )
+  }
+
+  // Reentrant: a tx is already open in this context — reuse it.
+  if (cell.tx) return run(cell.tx as TTransaction)
+
+  const audit = cell.resolved ?? (cell.resolved = await cell.resolve())
+
+  return db.transaction(async (tx) => {
+    await setAuditContext(tx, audit.actorId, contextKey, {
+      context: audit.context,
+    })
+    cell.tx = tx
+    try {
+      return await run(tx)
+    } finally {
+      cell.tx = null
+    }
+  })
+}

--- a/packages/drizzle_audit/test/context.integration.test.ts
+++ b/packages/drizzle_audit/test/context.integration.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { PGlite } from "@electric-sql/pglite"
+import { asc, eq } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/pglite"
+import { pgTable, text } from "drizzle-orm/pg-core"
+
+import {
+  currentAudit,
+  ensureAuditedTx,
+  hasAuditContext,
+  maybeCurrentAudit,
+  runWithAuditContext,
+} from "../src/context/index.js"
+import {
+  createAttachAuditTriggersSql,
+  createAuditInstallSql,
+  pgAuditLogTable,
+} from "../src/postgres/index.js"
+
+const users = pgTable("users", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+})
+
+const contextColumns = [{ column: "workspace_id" }]
+const auditLogs = pgAuditLogTable({ contextColumns })
+
+async function makeDb() {
+  const client = new PGlite()
+  const db = drizzle({ client, schema: { auditLogs, users } })
+  await client.exec(createAuditInstallSql({ contextColumns }))
+  await client.exec(`
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL
+    );
+  `)
+  await client.exec(createAttachAuditTriggersSql([{ table: "users" }]))
+  return db
+}
+
+test("ensureAuditedTx stamps the ambient actor + context columns", async () => {
+  const db = await makeDb()
+
+  await runWithAuditContext(
+    { actorId: "user_123", context: { "app.workspace_id": "ws_1" } },
+    () =>
+      ensureAuditedTx(db, async (tx) => {
+        await tx.insert(users).values({ id: "u1", name: "Ada" })
+        await tx.update(users).set({ name: "Ada Lovelace" }).where(eq(users.id, "u1"))
+      }),
+  )
+
+  const logs = await db.select().from(auditLogs).orderBy(asc(auditLogs.id))
+  assert.equal(logs.length, 2)
+  assert.equal(logs[0]?.operation, "INSERT")
+  assert.equal(logs[0]?.user_id, "user_123")
+  assert.equal((logs[0] as { workspace_id?: string }).workspace_id, "ws_1")
+  assert.equal(logs[1]?.operation, "UPDATE")
+  assert.equal(logs[1]?.user_id, "user_123")
+})
+
+test("nested ensureAuditedTx reuses one transaction (reentrant)", async () => {
+  const db = await makeDb()
+
+  let outerTx: unknown
+  let innerTx: unknown
+
+  await runWithAuditContext({ actorId: "user_42" }, () =>
+    ensureAuditedTx(db, async (tx) => {
+      outerTx = tx
+      await tx.insert(users).values({ id: "a", name: "A" })
+      // A nested unit (e.g. another service method) must reuse the open tx.
+      await ensureAuditedTx(db, async (tx2) => {
+        innerTx = tx2
+        await tx2.insert(users).values({ id: "b", name: "B" })
+      })
+    }),
+  )
+
+  assert.equal(outerTx, innerTx, "nested call should reuse the same tx instance")
+  const logs = await db.select().from(auditLogs)
+  assert.equal(logs.length, 2)
+  assert.ok(logs.every((l) => l.user_id === "user_42"))
+})
+
+test("lazy resolver runs once, on first write; currentAudit reads it", async () => {
+  const db = await makeDb()
+
+  let resolved = 0
+  let seenActor: string | undefined
+
+  await runWithAuditContext(
+    () => {
+      resolved++
+      return { actorId: "lazy_user" }
+    },
+    async () => {
+      // Not resolved yet — no write has happened.
+      assert.equal(maybeCurrentAudit(), null)
+      assert.equal(resolved, 0)
+
+      await ensureAuditedTx(db, async (tx) => {
+        seenActor = currentAudit().actorId
+        await tx.insert(users).values({ id: "x", name: "X" })
+        // Reentrant call must NOT resolve again.
+        await ensureAuditedTx(db, async (tx2) => {
+          await tx2.insert(users).values({ id: "y", name: "Y" })
+        })
+      })
+    },
+  )
+
+  assert.equal(resolved, 1, "resolver runs exactly once")
+  assert.equal(seenActor, "lazy_user")
+})
+
+test("guardrail: audited write / currentAudit outside a context throw", async () => {
+  const db = await makeDb()
+
+  assert.equal(hasAuditContext(), false)
+  assert.throws(() => currentAudit(), /no ambient audit context/)
+  await assert.rejects(
+    () => ensureAuditedTx(db, async () => {}),
+    /outside an audit context/,
+  )
+})

--- a/packages/drizzle_audit/test/context.test.ts
+++ b/packages/drizzle_audit/test/context.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  currentAudit,
+  ensureAuditedTx,
+  hasAuditContext,
+  maybeCurrentAudit,
+  runWithAuditContext,
+} from "../src/context/index.js"
+
+// A minimal fake of the drizzle surface `ensureAuditedTx` needs: a
+// transaction-capable db whose tx records the SQL passed to `execute` (which is
+// how setAuditContext writes the actor/context GUCs). No real database — this
+// exercises the ALS plumbing (resolution, reentrancy, guardrail) deterministically.
+type FakeTx = { execute(query: unknown): Promise<unknown> }
+
+function makeFakeDb() {
+  let txCount = 0
+  const executed: unknown[] = []
+  const tx: FakeTx = {
+    async execute(query: unknown) {
+      executed.push(query)
+      return undefined
+    },
+  }
+  const db = {
+    async transaction<T>(cb: (tx: FakeTx) => Promise<T>): Promise<T> {
+      txCount++
+      return cb(tx)
+    },
+  }
+  return {
+    db,
+    tx,
+    executed,
+    get txCount() {
+      return txCount
+    },
+  }
+}
+
+test("ensureAuditedTx opens one tx and writes the actor GUC", async () => {
+  const fake = makeFakeDb()
+  let inside: unknown
+
+  await runWithAuditContext({ actorId: "user_1" }, () =>
+    ensureAuditedTx(fake.db, async (tx) => {
+      inside = tx
+    }),
+  )
+
+  assert.equal(fake.txCount, 1)
+  assert.equal(inside, fake.tx)
+  // setAuditContext ran at least the actor set_config.
+  assert.ok(fake.executed.length >= 1)
+})
+
+test("nested ensureAuditedTx reuses the open tx (no second transaction)", async () => {
+  const fake = makeFakeDb()
+  const seen: unknown[] = []
+
+  await runWithAuditContext({ actorId: "user_1" }, () =>
+    ensureAuditedTx(fake.db, async (tx) => {
+      seen.push(tx)
+      await ensureAuditedTx(fake.db, async (tx2) => {
+        seen.push(tx2)
+        await ensureAuditedTx(fake.db, async (tx3) => seen.push(tx3))
+      })
+    }),
+  )
+
+  assert.equal(fake.txCount, 1, "only one transaction is opened")
+  assert.equal(seen.length, 3)
+  assert.ok(seen.every((t) => t === fake.tx))
+})
+
+test("lazy resolver runs exactly once, on first write", async () => {
+  const fake = makeFakeDb()
+  let resolved = 0
+  let seenActor: string | undefined
+
+  await runWithAuditContext(
+    () => {
+      resolved++
+      return { actorId: "lazy" }
+    },
+    async () => {
+      assert.equal(resolved, 0, "not resolved before any write")
+      assert.equal(maybeCurrentAudit(), null)
+
+      await ensureAuditedTx(fake.db, async () => {
+        seenActor = currentAudit().actorId
+        // reentrant — must not re-resolve
+        await ensureAuditedTx(fake.db, async () => {})
+      })
+
+      // resolved value is memoised on the cell
+      assert.equal(maybeCurrentAudit()?.actorId, "lazy")
+    },
+  )
+
+  assert.equal(resolved, 1)
+  assert.equal(seenActor, "lazy")
+})
+
+test("eager context resolves immediately (currentAudit before any write)", async () => {
+  await runWithAuditContext(
+    { actorId: "eager", context: { "app.workspace_id": "ws_9" } },
+    async () => {
+      assert.equal(currentAudit().actorId, "eager")
+      assert.equal(currentAudit().context?.["app.workspace_id"], "ws_9")
+    },
+  )
+})
+
+test("guardrail: writes / reads outside a context fail loudly", async () => {
+  const fake = makeFakeDb()
+
+  assert.equal(hasAuditContext(), false)
+  assert.equal(maybeCurrentAudit(), null)
+  assert.throws(() => currentAudit(), /no ambient audit context/)
+  await assert.rejects(
+    () => ensureAuditedTx(fake.db, async () => {}),
+    /outside an audit context/,
+  )
+  assert.equal(fake.txCount, 0)
+})
+
+test("context is isolated per runWithAuditContext scope", async () => {
+  const a = runWithAuditContext({ actorId: "A" }, async () => {
+    await Promise.resolve()
+    return currentAudit().actorId
+  })
+  const b = runWithAuditContext({ actorId: "B" }, async () => {
+    await Promise.resolve()
+    return currentAudit().actorId
+  })
+  assert.deepEqual(await Promise.all([a, b]), ["A", "B"])
+})

--- a/packages/drizzle_audit/tsconfig.json
+++ b/packages/drizzle_audit/tsconfig.json
@@ -12,5 +12,10 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["node_modules", "dist", "test/postgres.integration.test.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test/postgres.integration.test.ts",
+    "test/context.integration.test.ts"
+  ]
 }


### PR DESCRIPTION
## What

Adds an opt-in `@willyim/drizzle-audit/context` export — an **ambient** audit layer on top of the existing explicit `withAuditedTransaction`.

Establish "who is acting" **once** at an entry boundary (a request, a job, an engine tick) with `runWithAuditContext`, then open-or-reuse **one** audited transaction anywhere below with `ensureAuditedTx` — the actor is read from the ambient store instead of being threaded through every call signature. The dual UI-vs-system fork in service methods collapses into one method.

### New export: `@willyim/drizzle-audit/context`

| Export | Description |
|---|---|
| `runWithAuditContext(audit, fn)` | Set the ambient actor for `fn` (an `AuditContext` or a **lazy thunk** resolved on first write) |
| `ensureAuditedTx(db, run, contextKey?)` | Open-or-reuse one audited tx; reentrant; actor from the ambient context |
| `currentAudit()` / `maybeCurrentAudit()` | Read the resolved actor (e.g. to stamp a domain `createdBy` column) |
| `hasAuditContext()` | Whether a context is in scope |

## Design notes

- **Lazy resolution** — pass a thunk and the actor resolves only when the first audited write happens, so read-only requests never pay to resolve a session.
- **Reentrant** — nested `ensureAuditedTx` calls share one transaction; reads never open a tx.
- **Guardrail** — an audited write with no ambient context throws loudly (no unattributed writes).
- **Runtime support** — uses *only* `AsyncLocalStorage` from `node:async_hooks` (the subset Cloudflare Workers implements), so it runs on Node, Bun, and Workers (`nodejs_compat`). The import throws loudly where ALS is absent; the explicit `withAuditedTransaction` stays the cross-runtime floor.

## Tests

- `test/context.test.ts` (runs in CI): fake-db unit tests — resolution, reentrancy (one tx), lazy-once, guardrail, per-scope isolation.
- `test/context.integration.test.ts` (PGlite end-to-end, excluded from CI build like `postgres.integration.test.ts`): real triggers + GUC context columns through `ensureAuditedTx`. All green locally.

Bumps `0.5.0` → `0.6.0`. Merging to `main` triggers `publish-drizzle-audit.yml` → npm publish.

Consumed by kasso#34.