### PR TITLE
feat(drizzle-audit)!: column-keyed context + options-bag runtime API (0.7.0)

### DIFF
--- a/packages/drizzle_audit/README.md
+++ b/packages/drizzle_audit/README.md
@@ -144,11 +144,12 @@ const contextColumns = [{ column: "workspace_id" }, { column: "tenant_id" }]
 createAuditInstallSql({ contextColumns })
 export const auditLogs = pgAuditLogTable({ contextColumns })
 
-// Pass context at runtime (GUC name → value)
+// Pass context at runtime, keyed by COLUMN name. Each value is written to the
+// GUC `app.${column}` (matching the trigger's default sessionKey). Override the
+// prefix with `contextPrefix`, or set it to "" to pass fully-qualified keys.
 await withAuditedTransaction(
   db, userId, async (tx) => { /* ... */ },
-  "app.user_id",
-  { context: { "app.workspace_id": "ws_1", "app.tenant_id": "t_1" } },
+  { context: { workspace_id: "ws_1", tenant_id: "t_1" } },
 )
 ```
 
@@ -202,7 +203,7 @@ app.use((req, next) =>
   runWithAuditContext(
     async () => ({
       actorId: (await getSession(req)).userId,
-      context: { "app.workspace_id": req.workspaceId },
+      context: { workspace_id: req.workspaceId },
     }),
     next,
   ),
@@ -272,8 +273,8 @@ export function createAuditSql() {
 | `createAttachAuditTriggerSql(target, options?)` | SQL to attach audit trigger to one table |
 | `createAttachAuditTriggersSql(targets, options?)` | Same, for multiple tables |
 | `createAuditAddContextColumnsSql(options)` | SQL to add context columns + regenerate trigger on existing install |
-| `setAuditContext(db, actorId, contextKey?, options?)` | Set actor context in current transaction |
-| `withAuditedTransaction(db, actorId, callback, contextKey?, options?)` | Transaction wrapper with actor context |
+| `setAuditContext(db, actorId, options?)` | Set actor + context GUCs in the current transaction |
+| `withAuditedTransaction(db, actorId, callback, options?)` | Transaction wrapper with actor context |
 
 ### `@willyim/drizzle-audit/context`
 
@@ -282,7 +283,7 @@ Opt-in ambient layer (AsyncLocalStorage). See [Ambient Context](#ambient-context
 | Export | Description |
 |---|---|
 | `runWithAuditContext(audit, fn)` | Set the ambient actor for `fn` (`audit` is an `AuditContext` or a lazy thunk) |
-| `ensureAuditedTx(db, run, contextKey?)` | Open-or-reuse one audited tx; actor read from the ambient context |
+| `ensureAuditedTx(db, run, options?)` | Open-or-reuse one audited tx; actor read from the ambient context |
 | `currentAudit()` | The resolved ambient `AuditContext` (throws if absent/unresolved) |
 | `maybeCurrentAudit()` | The resolved ambient `AuditContext`, or `null` |
 | `hasAuditContext()` | Whether an ambient context is in scope |
@@ -398,6 +399,23 @@ CREATE TABLE audit_logs (
 | **User context** | Native session vars | Available in JS | `_audit_context` table |
 | **Bypass risk** | Low (DB-level) | Medium (must use wrapper) | Low (DB-level) |
 | **Best for** | Postgres apps | D1/Cloudflare Workers | SQLite apps needing DB-level guarantees |
+
+## Migrating from 0.6.x → 0.7.0
+
+The Postgres runtime now takes a single options bag and keys `context` by
+**column name** (the library prepends `app.`), matching the D1 runtime and the
+`contextColumns` config. The positional `contextKey` argument is gone.
+
+| Before (0.6) | After (0.7) |
+|---|---|
+| `setAuditContext(db, actorId, "app.user_id", { context: { "app.workspace_id": v } })` | `setAuditContext(db, actorId, { context: { workspace_id: v } })` |
+| `withAuditedTransaction(db, actorId, cb, "app.user_id", { context: { "app.workspace_id": v } })` | `withAuditedTransaction(db, actorId, cb, { context: { workspace_id: v } })` |
+| `withAuditedTransaction(db, actorId, cb, "myapp.actor")` | `withAuditedTransaction(db, actorId, cb, { actorKey: "myapp.actor" })` |
+| `ensureAuditedTx(db, run, "app.user_id")` | `ensureAuditedTx(db, run, { actorKey: "app.user_id" })` |
+| `AuditContext.context = { "app.workspace_id": v }` | `AuditContext.context = { workspace_id: v }` |
+
+If a context column uses a custom `sessionKey` (not `app.${column}`), set
+`contextPrefix: ""` and pass the fully-qualified GUC name as the key.
 
 ## Migrating from 0.2.x → 0.3.0
 

--- a/packages/drizzle_audit/package.json
+++ b/packages/drizzle_audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-audit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Lightweight audit logging for Drizzle ORM using database triggers (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/drizzle_audit/src/context/index.ts
+++ b/packages/drizzle_audit/src/context/index.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 
-import { setAuditContext } from "../postgres/runtime.js"
+import { setAuditContext, type AuditContextOptions } from "../postgres/runtime.js"
 import type {
   AuditSqlExecutor,
   AuditTransactionCapable,
@@ -35,11 +35,14 @@ if (typeof AsyncLocalStorage === "undefined") {
   )
 }
 
-/** Opaque to the library: an actor string + the GUC map written for the tx. */
+/** Opaque to the library: an actor string + the context map written for the tx. */
 export type AuditContext = {
   /** Value written to the actor GUC (default `app.user_id`). */
   actorId: string
-  /** Extra session GUCs (full GUC name → value), e.g. `app.workspace_id`. */
+  /**
+   * Context values keyed by **column name** (e.g. `workspace_id`), written to
+   * `app.${column}` GUCs. See {@link AuditContextOptions.context}.
+   */
   context?: Record<string, string>
 }
 
@@ -123,7 +126,7 @@ export async function ensureAuditedTx<
 >(
   db: AuditTransactionCapable<TTransaction>,
   run: (tx: TTransaction) => Promise<TResult> | TResult,
-  contextKey = "app.user_id",
+  options?: Omit<AuditContextOptions, "context">,
 ): Promise<TResult> {
   const cell = als.getStore()
   if (!cell) {
@@ -139,9 +142,7 @@ export async function ensureAuditedTx<
   const audit = cell.resolved ?? (cell.resolved = await cell.resolve())
 
   return db.transaction(async (tx) => {
-    await setAuditContext(tx, audit.actorId, contextKey, {
-      context: audit.context,
-    })
+    await setAuditContext(tx, audit.actorId, { ...options, context: audit.context })
     cell.tx = tx
     try {
       return await run(tx)

--- a/packages/drizzle_audit/src/postgres/runtime.ts
+++ b/packages/drizzle_audit/src/postgres/runtime.ts
@@ -5,48 +5,50 @@ import type {
   AuditTransactionCapable,
 } from "./types.js"
 
+const DEFAULT_ACTOR_KEY = "app.user_id"
+const DEFAULT_CONTEXT_PREFIX = "app."
+
 function assertActorId(actorId: string) {
   if (actorId.trim().length === 0) {
     throw new Error("actorId must not be empty")
   }
 }
 
-/**
- * Builds the `context` GUC map from a set of options. Empty/undefined values
- * are dropped so the trigger's NULLIF yields NULL.
- */
-function resolveContext(options?: AuditContextOptions): Record<string, string> {
-  const context: Record<string, string> = {}
-
-  for (const [key, value] of Object.entries(options?.context ?? {})) {
-    if (value !== undefined && value !== "") {
-      context[key] = value
-    }
-  }
-
-  return context
-}
-
 export type AuditContextOptions = {
-  /** Map of session GUC name → value to set for the transaction. */
+  /** GUC that receives the actor id. Default `app.user_id`. */
+  actorKey?: string
+  /**
+   * Context values keyed by **column name** (e.g. `workspace_id`). Each is
+   * written to the GUC `${contextPrefix}${column}`, matching the trigger's
+   * default `sessionKey` of `app.${column}`. Empty/`undefined` values are
+   * dropped so the column stays NULL.
+   */
   context?: Record<string, string>
+  /**
+   * Prefix prepended to each context column name to form its GUC. Default
+   * `app.`. Set to `""` to pass fully-qualified GUC names in `context` (e.g.
+   * when a column uses a custom `sessionKey`).
+   */
+  contextPrefix?: string
 }
 
 export async function setAuditContext(
   db: AuditSqlExecutor,
   actorId: string,
-  contextKey = "app.user_id",
   options?: AuditContextOptions,
 ) {
   assertActorId(actorId)
 
+  const actorKey = options?.actorKey ?? DEFAULT_ACTOR_KEY
   await db.execute(
-    sql`select set_config(${contextKey}, ${actorId}, true) as audit_context`,
+    sql`select set_config(${actorKey}, ${actorId}, true) as audit_context`,
   )
 
-  for (const [key, value] of Object.entries(resolveContext(options))) {
+  const prefix = options?.contextPrefix ?? DEFAULT_CONTEXT_PREFIX
+  for (const [column, value] of Object.entries(options?.context ?? {})) {
+    if (value === undefined || value === "") continue
     await db.execute(
-      sql`select set_config(${key}, ${value}, true) as audit_context`,
+      sql`select set_config(${prefix + column}, ${value}, true) as audit_context`,
     )
   }
 }
@@ -58,13 +60,12 @@ export async function withAuditedTransaction<
   db: AuditTransactionCapable<TTransaction>,
   actorId: string,
   callback: (tx: TTransaction) => Promise<TResult> | TResult,
-  contextKey = "app.user_id",
   options?: AuditContextOptions,
 ) {
   assertActorId(actorId)
 
   return db.transaction(async (tx) => {
-    await setAuditContext(tx, actorId, contextKey, options)
+    await setAuditContext(tx, actorId, options)
     return await callback(tx)
   })
 }

--- a/packages/drizzle_audit/test/context.integration.test.ts
+++ b/packages/drizzle_audit/test/context.integration.test.ts
@@ -45,7 +45,7 @@ test("ensureAuditedTx stamps the ambient actor + context columns", async () => {
   const db = await makeDb()
 
   await runWithAuditContext(
-    { actorId: "user_123", context: { "app.workspace_id": "ws_1" } },
+    { actorId: "user_123", context: { workspace_id: "ws_1" } },
     () =>
       ensureAuditedTx(db, async (tx) => {
         await tx.insert(users).values({ id: "u1", name: "Ada" })

--- a/packages/drizzle_audit/test/context.test.ts
+++ b/packages/drizzle_audit/test/context.test.ts
@@ -106,10 +106,10 @@ test("lazy resolver runs exactly once, on first write", async () => {
 
 test("eager context resolves immediately (currentAudit before any write)", async () => {
   await runWithAuditContext(
-    { actorId: "eager", context: { "app.workspace_id": "ws_9" } },
+    { actorId: "eager", context: { workspace_id: "ws_9" } },
     async () => {
       assert.equal(currentAudit().actorId, "eager")
-      assert.equal(currentAudit().context?.["app.workspace_id"], "ws_9")
+      assert.equal(currentAudit().context?.["workspace_id"], "ws_9")
     },
   )
 })

--- a/packages/drizzle_audit/test/postgres.integration.test.ts
+++ b/packages/drizzle_audit/test/postgres.integration.test.ts
@@ -262,8 +262,7 @@ test("workspace_id column and context are stored when enabled", async () => {
       async (tx) => {
         await tx.insert(users).values({ id: "u1", name: "Alice" })
       },
-      "app.user_id",
-      { context: { "app.workspace_id": "ws_1" } },
+      { context: { workspace_id: "ws_1" } },
     )
 
     const logs = await db.select().from(auditLogsWithWorkspace)
@@ -318,8 +317,7 @@ test("custom context column name uses matching session key", async () => {
       async (tx) => {
         await tx.insert(users).values({ id: "u1", name: "Alice" })
       },
-      "app.user_id",
-      { context: { "app.tenant_id": "tenant_abc" } },
+      { context: { tenant_id: "tenant_abc" } },
     )
 
     const logs = await db.select().from(auditLogsWithTenant)
@@ -365,12 +363,11 @@ test("generic contextColumns populate and stay NULL without context", async () =
           .where(eq(users.id, "u1"))
         await tx.delete(users).where(eq(users.id, "u1"))
       },
-      "app.user_id",
       {
         context: {
-          "app.workspace_id": "ws_1",
-          "app.tenant_id": "tenant_1",
-          "app.request_id": "req_1",
+          workspace_id: "ws_1",
+          tenant_id: "tenant_1",
+          request_id: "req_1",
         },
       },
     )
@@ -445,11 +442,10 @@ test("createAuditAddContextColumnsSql adds a column and regenerates trigger", as
       async (tx) => {
         await tx.insert(users).values({ id: "u1", name: "Alice" })
       },
-      "app.user_id",
       {
         context: {
-          "app.workspace_id": "ws_1",
-          "app.request_id": "req_99",
+          workspace_id: "ws_1",
+          request_id: "req_99",
         },
       },
     )
@@ -495,7 +491,7 @@ test("custom context key for user_id works", async () => {
       async (tx) => {
         await tx.insert(users).values({ id: "u1", name: "Alice" })
       },
-      "myapp.actor",
+      { actorKey: "myapp.actor" },
     )
 
     const logs = await db.select().from(auditLogs).orderBy(asc(auditLogs.id))


### PR DESCRIPTION
## Breaking change (0.6.0 → 0.7.0)

Fixes a cross-dialect inconsistency: the **Postgres** runtime keyed `context` by fully-qualified GUC name (`{ "app.workspace_id": v }`) while **D1** and the `contextColumns` config key by **column name** (`{ workspace_id }`). Now the Postgres runtime keys `context` by column name too — the library prepends `app.` (configurable) — so runtime, config, and D1 all speak the same vocabulary. The awkward positional `contextKey` argument is folded into the options bag.

### API

```ts
type AuditContextOptions = {
  actorKey?: string        // GUC for the actor. Default "app.user_id"
  context?: Record<string, string>  // keyed by COLUMN name → app.${column}
  contextPrefix?: string   // default "app."; set "" to pass full GUC names
}

setAuditContext(db, actorId, options?)
withAuditedTransaction(db, actorId, callback, options?)
ensureAuditedTx(db, run, options?)   // options omits `context` (comes from ambient)
```

`AuditContext.context` (the ambient `/context` export) is now column-keyed as well.

### Migration

| Before | After |
|---|---|
| `withAuditedTransaction(db, id, cb, "app.user_id", { context: { "app.workspace_id": v } })` | `withAuditedTransaction(db, id, cb, { context: { workspace_id: v } })` |
| `withAuditedTransaction(db, id, cb, "myapp.actor")` | `withAuditedTransaction(db, id, cb, { actorKey: "myapp.actor" })` |
| `ensureAuditedTx(db, run, "app.user_id")` | `ensureAuditedTx(db, run, { actorKey: "app.user_id" })` |

Custom `sessionKey` columns: set `contextPrefix: ""` and pass full GUC keys.

### Why now

Pre-1.0, and the only consumer is kasso — so the migration is a one-line-per-callsite bump on a branch already touching every audit call site. `AuditContext`/`ensureAuditedTx` shipped in 0.6.0 with ~zero external adoption, so reshaping them now is essentially free.

### Tests

- CI unit set (fake-db) green.
- PGlite end-to-end (excluded from CI like the existing postgres test) — all 12 green locally, incl. column-keyed context → `app.${column}` GUC → trigger → column, custom `actorKey`, and multi-column context.

D1 runtime unchanged (already column-keyed).