### PR TITLE
fix(drizzle-audit)!: CLI — inherit TTY for drizzle-kit prompts, append audit SQL only on change (0.8.0)

### DIFF
--- a/packages/drizzle_audit/README.md
+++ b/packages/drizzle_audit/README.md
@@ -245,6 +245,23 @@ npx drizzle-audit generate \
   --migrations-dir drizzle
 ```
 
+Any argument the CLI doesn't recognize (and anything after `--`) is passed
+through to `drizzle-kit generate`, so `--name` and `--custom` work. drizzle-kit
+runs with your terminal's stdio, so its interactive prompts (rename vs create)
+behave exactly as they do when you run drizzle-kit directly.
+
+The audit SQL is appended **only when it changed** since the last time it was
+shipped, tracked by a hash in `<migrations-dir>/.drizzle-audit.json` — commit
+that file. Migrations that don't touch the audit config stay free of trigger
+DDL, and a diff carrying the `-- drizzle-audit <hash>` block is a signal that
+the audit setup actually moved. If the audit SQL changes but your schema
+didn't, the CLI exits non-zero and tells you to create an empty migration for
+it:
+
+```bash
+npx drizzle-audit generate --config app/db/audit.ts -- --custom --name audit-update
+```
+
 Your config file exports a `createAuditSql()` function:
 
 ```ts

--- a/packages/drizzle_audit/package.json
+++ b/packages/drizzle_audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/drizzle-audit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Lightweight audit logging for Drizzle ORM using database triggers (Postgres + D1/SQLite)",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/drizzle_audit/src/cli/generate-migration.ts
+++ b/packages/drizzle_audit/src/cli/generate-migration.ts
@@ -3,37 +3,52 @@
  * CLI: run drizzle-kit generate, then append audit SQL from the consumer's
  * config to the newly created migration file.
  *
- * Usage: drizzle-audit generate [options]
+ * The audit SQL is only appended when (a) drizzle-kit actually created a new
+ * migration and (b) the generated audit SQL differs from what the last
+ * migration shipped (tracked by hash in <migrations-dir>/.drizzle-audit.json).
+ * This keeps trigger DDL out of migrations that don't change it.
+ *
+ * Usage: drizzle-audit generate [options] [-- extra drizzle-kit args]
  * Options:
  *   --config <path>         Path to audit config (TS or JS) exporting createAuditSql/createWebAuditSql
  *   --drizzle-config <path> Path to drizzle config for drizzle-kit (default: drizzle.config.ts)
  *   --migrations-dir <path> Dir for migrations relative to cwd (default: drizzle)
  *   --cwd <path>            Working directory (default: process.cwd())
+ *
+ * Any argument not listed above (e.g. --name, --custom) is passed through to
+ * `drizzle-kit generate` verbatim.
  */
 
-import { execSync, spawnSync } from "node:child_process"
-import { readFileSync, readdirSync, writeFileSync } from "node:fs"
-import { resolve } from "node:path"
+import { execFileSync, spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 const DEFAULT_DRIZZLE_CONFIG = "drizzle.config.ts"
 const DEFAULT_MIGRATIONS_DIR = "drizzle"
+const STATE_FILE = ".drizzle-audit.json"
+const MARKER = "-- drizzle-audit"
 
 function parseArgs(): {
   config: string
   drizzleConfig: string
   migrationsDir: string
   cwd: string
+  passthrough: string[]
 } {
   const args = process.argv.slice(2)
   if (args[0] !== "generate") {
-    console.error("Usage: drizzle-audit generate --config <path> [options]")
+    console.error(
+      "Usage: drizzle-audit generate --config <path> [options] [-- extra drizzle-kit args]",
+    )
     process.exit(1)
   }
   let config = ""
   let drizzleConfig = DEFAULT_DRIZZLE_CONFIG
   let migrationsDir = DEFAULT_MIGRATIONS_DIR
   let cwd = process.cwd()
+  const passthrough: string[] = []
   for (let i = 1; i < args.length; i++) {
     if (args[i] === "--config" && args[i + 1]) {
       config = args[++i]
@@ -43,51 +58,82 @@ function parseArgs(): {
       migrationsDir = args[++i]
     } else if (args[i] === "--cwd" && args[i + 1]) {
       cwd = args[++i]
+    } else if (args[i] === "--") {
+      passthrough.push(...args.slice(i + 1))
+      break
+    } else {
+      passthrough.push(args[i])
     }
   }
   if (!config) {
     console.error("Missing required --config <path>")
     process.exit(1)
   }
-  return { config, drizzleConfig, migrationsDir, cwd }
+  return { config, drizzleConfig, migrationsDir, cwd, passthrough }
 }
 
-function findNewestMigrationDir(migrationsDir: string): string {
-  const abs = resolve(migrationsDir)
-  const entries = readdirSync(abs, { withFileTypes: true })
-  const dirs = entries
+function listMigrationDirs(migrationsAbs: string): string[] {
+  if (!existsSync(migrationsAbs)) {
+    return []
+  }
+  return readdirSync(migrationsAbs, { withFileTypes: true })
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
     .filter((n) => /^\d+_.+/.test(n))
     .sort()
-  const newest = dirs[dirs.length - 1]
-  if (!newest) {
-    throw new Error(`No migration folders found in ${abs}`)
+}
+
+function readStateHash(statePath: string): string | undefined {
+  if (!existsSync(statePath)) {
+    return undefined
   }
-  return resolve(abs, newest)
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, "utf-8")) as {
+      hash?: string
+    }
+    return typeof parsed.hash === "string" ? parsed.hash : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Resolves the drizzle-kit binary from the nearest node_modules/.bin, walking
+ * up from cwd. Falls back to a bare "drizzle-kit" (PATH lookup) so globally
+ * installed setups keep working. Never uses npx: npx skips PATH and silently
+ * network-installs when the package isn't in a local node_modules.
+ */
+function resolveDrizzleKit(cwd: string): string {
+  let dir = cwd
+  for (;;) {
+    const candidate = resolve(dir, "node_modules", ".bin", "drizzle-kit")
+    if (existsSync(candidate)) {
+      return candidate
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      return "drizzle-kit"
+    }
+    dir = parent
+  }
 }
 
 async function getAuditSql(configPath: string, cwd: string): Promise<string> {
   const resolved = resolve(cwd, configPath)
-  const ext = resolved.endsWith(".ts")
-    ? ".ts"
-    : resolved.endsWith(".mts")
-      ? ".mts"
-      : ""
-  if (ext) {
+  const isTs = /\.[cm]?ts$/.test(resolved)
+  if (isTs) {
     try {
       const __dirname = fileURLToPath(new URL(".", import.meta.url))
       const runnerPath = resolve(__dirname, "runner.js")
-      const out = execSync(
-        `node --experimental-strip-types "${runnerPath}" "${resolved}"`,
+      const out = execFileSync(
+        "node",
+        ["--experimental-strip-types", runnerPath, resolved],
         { cwd, encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
       )
       return out.trim()
     } catch (e) {
       const err = e as { message?: string; stderr?: string }
-      console.error(
-        "Failed to load .ts config. Requires Node >= 22.6.0.",
-      )
+      console.error("Failed to load .ts config. Requires Node >= 22.6.0.")
       console.error(err.stderr ?? err.message)
       process.exit(1)
     }
@@ -105,31 +151,82 @@ async function getAuditSql(configPath: string, cwd: string): Promise<string> {
 }
 
 async function main() {
-  const { config, drizzleConfig, migrationsDir, cwd } = parseArgs()
+  const { config, drizzleConfig, migrationsDir, cwd, passthrough } = parseArgs()
   const drizzleConfigPath = resolve(cwd, drizzleConfig)
   const migrationsAbs = resolve(cwd, migrationsDir)
 
+  const before = new Set(listMigrationDirs(migrationsAbs))
+
   console.log("Running drizzle-kit generate...")
   const kit = spawnSync(
-    "npx",
-    ["drizzle-kit", "generate", "--config", drizzleConfigPath],
+    resolveDrizzleKit(cwd),
+    ["generate", "--config", drizzleConfigPath, ...passthrough],
     {
       cwd,
-      stdio: ["pipe", "inherit", "inherit"],
-      input: "\n\n",
-      encoding: "utf-8",
+      // Fully inherit stdio so drizzle-kit's interactive prompts (e.g.
+      // rename vs create column) reach the user's terminal. Piping stdin
+      // used to auto-answer prompts with the default option — which for a
+      // column rename means drop + create, i.e. data loss.
+      stdio: "inherit",
     },
   )
   if (kit.status !== 0) {
     process.exit(kit.status ?? 1)
   }
 
-  const migrationDir = findNewestMigrationDir(migrationsAbs)
-  const migrationFile = resolve(migrationDir, "migration.sql")
-  const existing = readFileSync(migrationFile, "utf-8")
+  const created = listMigrationDirs(migrationsAbs).filter(
+    (name) => !before.has(name),
+  )
+
   const auditSql = await getAuditSql(config, cwd)
-  const separator = "\n\n"
-  writeFileSync(migrationFile, existing + separator + "-- drizzle-audit\n\n" + auditSql, "utf-8")
+  const hash = createHash("sha256").update(auditSql).digest("hex").slice(0, 12)
+  const statePath = resolve(migrationsAbs, STATE_FILE)
+  const previousHash = readStateHash(statePath)
+
+  if (created.length === 0) {
+    if (previousHash === hash) {
+      console.log("No new migration and audit SQL unchanged. Nothing to do.")
+      return
+    }
+    console.error(
+      "Audit SQL changed but drizzle-kit created no migration (no schema diff).",
+    )
+    console.error(
+      "Create an empty migration to carry the audit changes, e.g.:",
+    )
+    console.error("  drizzle-audit generate --config ... -- --custom --name audit-update")
+    process.exit(1)
+  }
+
+  if (created.length > 1) {
+    // drizzle-kit generate creates at most one migration per run; more than
+    // one new folder means something else wrote to the migrations dir.
+    console.error(
+      `Expected at most one new migration folder, found ${created.length}: ${created.join(", ")}`,
+    )
+    process.exit(1)
+  }
+
+  const migrationFile = resolve(migrationsAbs, created[0], "migration.sql")
+
+  if (previousHash === hash) {
+    console.log(
+      `Audit SQL unchanged (${hash}); not appending to ${migrationFile}`,
+    )
+    return
+  }
+
+  const existing = readFileSync(migrationFile, "utf-8")
+  if (existing.includes(MARKER)) {
+    console.log(`Audit SQL already present in ${migrationFile}; not appending.`)
+    return
+  }
+  writeFileSync(
+    migrationFile,
+    `${existing}\n\n${MARKER} ${hash}\n\n${auditSql}\n`,
+    "utf-8",
+  )
+  writeFileSync(statePath, `${JSON.stringify({ hash }, null, 2)}\n`, "utf-8")
   console.log("Appended audit SQL to", migrationFile)
 }
 

--- a/packages/drizzle_audit/test/cli.test.ts
+++ b/packages/drizzle_audit/test/cli.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+// Tests run from dist/test, the built CLI sits in dist/src/cli.
+const CLI = resolve(__dirname, "../src/cli/generate-migration.js")
+
+const AUDIT_SQL_V1 = "-- audit v1\nCREATE TABLE IF NOT EXISTS audit_logs (id BIGSERIAL);"
+const AUDIT_SQL_V2 = "-- audit v2\nCREATE TABLE IF NOT EXISTS audit_logs (id BIGSERIAL);"
+
+type Workspace = {
+  cwd: string
+  env: NodeJS.ProcessEnv
+  argsFile: string
+  setAuditSql: (sql: string) => void
+  cleanup: () => void
+}
+
+/**
+ * Builds a temp workspace with a fake `drizzle-kit` on PATH. The fake records
+ * its argv and creates the migration folder named by FAKE_KIT_CREATE (or
+ * nothing when unset), mimicking drizzle-kit's "No schema changes" path.
+ * PATH is built from scratch so the repo's real node_modules/.bin (which npm
+ * prepends when tests run via `npm test`) can't shadow the fake.
+ */
+function makeWorkspace(): Workspace {
+  const cwd = mkdtempSync(join(tmpdir(), "drizzle-audit-cli-"))
+  const binDir = join(cwd, "fake-bin")
+  mkdirSync(binDir)
+  mkdirSync(join(cwd, "drizzle"))
+
+  const argsFile = join(cwd, "kit-args.json")
+  const fakeKit = join(binDir, "drizzle-kit")
+  writeFileSync(
+    fakeKit,
+    `#!/usr/bin/env node
+const { mkdirSync, writeFileSync } = require("node:fs")
+const { join } = require("node:path")
+writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(2)))
+const create = process.env.FAKE_KIT_CREATE
+if (create) {
+  const dir = join(process.cwd(), "drizzle", create)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "migration.sql"), 'CREATE TABLE "t" ("id" integer);')
+} else {
+  console.log("No schema changes, nothing to migrate")
+}
+`,
+    "utf-8",
+  )
+  chmodSync(fakeKit, 0o755)
+
+  const configPath = join(cwd, "audit.config.js")
+  const setAuditSql = (sql: string) => {
+    writeFileSync(
+      configPath,
+      `export function createAuditSql() { return ${JSON.stringify(sql)} }\n`,
+      "utf-8",
+    )
+  }
+  setAuditSql(AUDIT_SQL_V1)
+
+  writeFileSync(join(cwd, "drizzle.config.ts"), "export default {}\n", "utf-8")
+
+  const env: NodeJS.ProcessEnv = {
+    PATH: [binDir, dirname(process.execPath), "/usr/bin", "/bin"].join(":"),
+    HOME: process.env.HOME,
+  }
+
+  return {
+    cwd,
+    env,
+    argsFile,
+    setAuditSql,
+    cleanup: () => rmSync(cwd, { recursive: true, force: true }),
+  }
+}
+
+function runCli(
+  ws: Workspace,
+  opts: { create?: string; extraArgs?: string[] } = {},
+) {
+  return spawnSync(
+    process.execPath,
+    [
+      CLI,
+      "generate",
+      "--config",
+      "audit.config.js",
+      "--drizzle-config",
+      "drizzle.config.ts",
+      "--migrations-dir",
+      "drizzle",
+      ...(opts.extraArgs ?? []),
+    ],
+    {
+      cwd: ws.cwd,
+      encoding: "utf-8",
+      env: {
+        ...ws.env,
+        ...(opts.create ? { FAKE_KIT_CREATE: opts.create } : {}),
+      },
+    },
+  )
+}
+
+function migrationSql(ws: Workspace, folder: string): string {
+  return readFileSync(join(ws.cwd, "drizzle", folder, "migration.sql"), "utf-8")
+}
+
+function countMarkers(sql: string): number {
+  return sql.split("-- drizzle-audit").length - 1
+}
+
+test("appends audit SQL to a newly created migration and writes the state file", () => {
+  const ws = makeWorkspace()
+  try {
+    const result = runCli(ws, { create: "0001_first" })
+    assert.equal(result.status, 0, result.stderr)
+
+    const sql = migrationSql(ws, "0001_first")
+    assert.match(sql, /CREATE TABLE "t"/)
+    assert.equal(countMarkers(sql), 1)
+    assert.ok(sql.includes(AUDIT_SQL_V1))
+
+    const statePath = join(ws.cwd, "drizzle", ".drizzle-audit.json")
+    assert.ok(existsSync(statePath))
+    const state = JSON.parse(readFileSync(statePath, "utf-8"))
+    assert.equal(typeof state.hash, "string")
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("does not append to the previous migration when drizzle-kit creates nothing", () => {
+  const ws = makeWorkspace()
+  try {
+    assert.equal(runCli(ws, { create: "0001_first" }).status, 0)
+
+    // Second run: empty schema diff. The old CLI appended the audit block to
+    // 0001_first a second time here.
+    const result = runCli(ws)
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Nothing to do/)
+    assert.equal(countMarkers(migrationSql(ws, "0001_first")), 1)
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("skips the append when the audit SQL is unchanged", () => {
+  const ws = makeWorkspace()
+  try {
+    assert.equal(runCli(ws, { create: "0001_first" }).status, 0)
+
+    const result = runCli(ws, { create: "0002_second" })
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Audit SQL unchanged/)
+    assert.equal(countMarkers(migrationSql(ws, "0002_second")), 0)
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("appends again when the audit SQL changes", () => {
+  const ws = makeWorkspace()
+  try {
+    assert.equal(runCli(ws, { create: "0001_first" }).status, 0)
+
+    ws.setAuditSql(AUDIT_SQL_V2)
+    const result = runCli(ws, { create: "0002_second" })
+    assert.equal(result.status, 0, result.stderr)
+
+    const sql = migrationSql(ws, "0002_second")
+    assert.equal(countMarkers(sql), 1)
+    assert.ok(sql.includes(AUDIT_SQL_V2))
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("fails loudly when the audit SQL changes but no migration was created", () => {
+  const ws = makeWorkspace()
+  try {
+    assert.equal(runCli(ws, { create: "0001_first" }).status, 0)
+
+    ws.setAuditSql(AUDIT_SQL_V2)
+    const result = runCli(ws)
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /Audit SQL changed but drizzle-kit created no migration/)
+    assert.equal(countMarkers(migrationSql(ws, "0001_first")), 1)
+  } finally {
+    ws.cleanup()
+  }
+})
+
+test("passes unknown args through to drizzle-kit", () => {
+  const ws = makeWorkspace()
+  try {
+    const result = runCli(ws, {
+      create: "0001_first",
+      extraArgs: ["--", "--custom", "--name", "audit-update"],
+    })
+    assert.equal(result.status, 0, result.stderr)
+
+    const kitArgs = JSON.parse(readFileSync(ws.argsFile, "utf-8"))
+    assert.deepEqual(kitArgs.slice(-3), ["--custom", "--name", "audit-update"])
+    assert.equal(kitArgs[0], "generate")
+  } finally {
+    ws.cleanup()
+  }
+})

--- a/packages/drizzle_audit/test/context.integration.test.ts
+++ b/packages/drizzle_audit/test/context.integration.test.ts
@@ -29,7 +29,7 @@ const auditLogs = pgAuditLogTable({ contextColumns })
 
 async function makeDb() {
   const client = new PGlite()
-  const db = drizzle({ client, schema: { auditLogs, users } })
+  const db = drizzle({ client })
   await client.exec(createAuditInstallSql({ contextColumns }))
   await client.exec(`
     CREATE TABLE users (

--- a/packages/drizzle_audit/test/postgres.integration.test.ts
+++ b/packages/drizzle_audit/test/postgres.integration.test.ts
@@ -501,3 +501,50 @@ test("custom context key for user_id works", async () => {
     await client.close()
   }
 })
+
+test("install + attach SQL is idempotent — re-applying does not break or double-log", async () => {
+  const client = new PGlite()
+  const db = drizzle({
+    client,
+    schema: { auditLogs, users },
+  })
+
+  try {
+    // Consumers ship the audit block in generated migrations, so a fresh
+    // database replays it once per migration that carried it. Applying the
+    // full install twice must be a no-op, not an error or a second trigger.
+    const installSql = [
+      createAuditInstallSql(),
+      createAttachAuditTriggersSql([{ table: "users" }]),
+    ].join("\n\n")
+
+    await client.exec(`
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL
+      );
+    `)
+    await client.exec(installSql)
+    await client.exec(installSql)
+    await client.exec(installSql)
+
+    await withAuditedTransaction(db, "user_1", async (tx) => {
+      await tx.insert(users).values({ id: "u1", name: "Alice" })
+    })
+
+    const logs = await db.select().from(auditLogs).orderBy(asc(auditLogs.id))
+    assert.equal(logs.length, 1)
+    assert.equal(logs[0]?.operation, "INSERT")
+
+    const triggers = await client.query<{ tgname: string }>(
+      `SELECT tgname FROM pg_trigger
+       WHERE tgrelid = 'users'::regclass AND NOT tgisinternal`,
+    )
+    assert.deepEqual(
+      triggers.rows.map((r) => r.tgname),
+      ["users_audit"],
+    )
+  } finally {
+    await client.close()
+  }
+})

--- a/packages/drizzle_audit/test/postgres.integration.test.ts
+++ b/packages/drizzle_audit/test/postgres.integration.test.ts
@@ -28,14 +28,7 @@ const auditLogs = pgAuditLogTable()
 
 test("postgres auditing works end to end", async () => {
   const client = new PGlite()
-  const db = drizzle({
-    client,
-    schema: {
-      auditLogs,
-      users,
-      invoices,
-    },
-  })
+  const db = drizzle({ client })
 
   try {
     await client.exec(createAuditInstallSql())
@@ -123,14 +116,7 @@ test("postgres auditing works end to end", async () => {
 
 test("migration SQL bundle installs and enforces audit context", async () => {
   const client = new PGlite()
-  const db = drizzle({
-    client,
-    schema: {
-      auditLogs,
-      users,
-      invoices,
-    },
-  })
+  const db = drizzle({ client })
 
   try {
     await client.exec(`
@@ -178,13 +164,7 @@ test("migration SQL bundle installs and enforces audit context", async () => {
 
 test("writes without audit context produce audit rows with user_id = NULL", async () => {
   const client = new PGlite()
-  const db = drizzle({
-    client,
-    schema: {
-      auditLogs,
-      users,
-    },
-  })
+  const db = drizzle({ client })
 
   try {
     await client.exec(createAuditInstallSql())
@@ -233,14 +213,7 @@ test("workspace_id column and context are stored when enabled", async () => {
   const auditLogsWithWorkspace = pgAuditLogTable({
     contextColumns: [{ column: "workspace_id" }],
   })
-  const db = drizzle({
-    client,
-    schema: {
-      auditLogs: auditLogsWithWorkspace,
-      users,
-      invoices,
-    },
-  })
+  const db = drizzle({ client })
 
   try {
     await client.exec(
@@ -288,13 +261,7 @@ test("custom context column name uses matching session key", async () => {
   const auditLogsWithTenant = pgAuditLogTable({
     contextColumns: [{ column: "tenant_id" }],
   })
-  const db = drizzle({
-    client,
-    schema: {
-      auditLogs: auditLogsWithTenant,
-      users,
-    },
-  })
+  const db = drizzle({ client })
 
   try {
     await client.exec(
@@ -337,10 +304,7 @@ test("generic contextColumns populate and stay NULL without context", async () =
     { column: "request_id" },
   ]
   const auditLogsWithCtx = pgAuditLogTable({ contextColumns })
-  const db = drizzle({
-    client,
-    schema: { auditLogs: auditLogsWithCtx, users },
-  })
+  const db = drizzle({ client })
 
   try {
     await client.exec(createAuditInstallSql({ contextColumns }))
@@ -410,10 +374,7 @@ test("createAuditAddContextColumnsSql adds a column and regenerates trigger", as
   const auditLogsAfter = pgAuditLogTable({
     contextColumns: [{ column: "workspace_id" }, { column: "request_id" }],
   })
-  const db = drizzle({
-    client,
-    schema: { auditLogs: auditLogsAfter, users },
-  })
+  const db = drizzle({ client })
 
   try {
     // 1) Install base table with a single context column.
@@ -463,10 +424,7 @@ test("createAuditAddContextColumnsSql adds a column and regenerates trigger", as
 
 test("custom context key for user_id works", async () => {
   const client = new PGlite()
-  const db = drizzle({
-    client,
-    schema: { auditLogs, users },
-  })
+  const db = drizzle({ client })
 
   try {
     await client.exec(
@@ -504,10 +462,7 @@ test("custom context key for user_id works", async () => {
 
 test("install + attach SQL is idempotent — re-applying does not break or double-log", async () => {
   const client = new PGlite()
-  const db = drizzle({
-    client,
-    schema: { auditLogs, users },
-  })
+  const db = drizzle({ client })
 
   try {
     // Consumers ship the audit block in generated migrations, so a fresh

--- a/packages/drizzle_audit/tsconfig.json
+++ b/packages/drizzle_audit/tsconfig.json
@@ -12,10 +12,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "test/postgres.integration.test.ts",
-    "test/context.integration.test.ts"
-  ]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Why

Found while using the CLI from kasso (`wovalle/kasso`), which is currently its only consumer:

1. **Interactive prompts were broken — and dangerous.** The drizzle-kit spawn used `stdio: ["pipe", "inherit", "inherit"]` with `input: "\n\n"`. You could *see* the rename-vs-create prompt but your keyboard was never connected to it, and the blind double-Enter accepted the cursor default. For a column rename the default is **create + drop, i.e. data loss**, silently. Today this hard-failed on a rename (`Error: Interactive prompts require a TTY terminal`), which is the lucky outcome.
2. **The audit block was appended to every migration, unconditionally.** kasso's numbers: 54 migrations, 52 carry the full ~209-line audit install block, 418 `CREATE TRIGGER` statements, ~90% of all migration SQL is repeated audit DDL. Worse, the CLI never checked that drizzle-kit actually created a migration — an empty schema diff appended the block a second time to the previous, already-applied file (4 doubled migrations in kasso). And because every migration re-emits triggers, a hand-fixed `rowIdColumn` was silently reverted by the next unrelated generate.

## What changed

- `stdio: "inherit"` — drizzle-kit prompts work exactly as when run directly.
- Snapshot the migrations dir before/after; only append to a folder drizzle-kit just created. Empty diff → clean no-op.
- Hash the generated audit SQL, track it in `<migrations-dir>/.drizzle-audit.json` (committed). Unchanged SQL is not appended — trigger DDL ships only when the audit config actually moved, and the `-- drizzle-audit <hash>` marker in a diff becomes a signal instead of noise.
- Audit SQL changed but no schema diff → exit 1 with a pointer to `-- --custom --name audit-update` (passthrough makes that work).
- Unknown args / everything after `--` pass through to `drizzle-kit generate` (`--name`, `--custom` were unreachable).
- Resolve drizzle-kit via nearest `node_modules/.bin` with PATH fallback instead of `npx`, which skips PATH and silently network-installs.
- `execFileSync` for the TS-config runner (config path was interpolated into a shell string); `.cts`/`.mts` now route through the runner too.

## Tests

- New `test/cli.test.ts` (6 tests, fake drizzle-kit on PATH): append + state file, no double-append on empty diff, skip on unchanged SQL, re-append on change, loud failure on config-change-without-migration, arg passthrough. The CLI previously had zero tests.
- Re-enabled `postgres.integration.test.ts` + `context.integration.test.ts` — they were excluded in tsconfig, so `npm test` never ran them (they pass on pglite, no infra needed).
- New integration test: install + attach SQL applied 3× is a no-op (one trigger, one audit row) — pins the property the migration-replay path depends on.

Local: 40 pass; the 23 failures are better-sqlite3's native binding vs Node 26 locally (pre-existing, unrelated — CI uses Node 22 and rebuilds).

## Breaking

Behavioral: migrations no longer carry the audit block by default; consumers must commit `.drizzle-audit.json`. Version bumped to 0.8.0.