### PR TITLE
idp: remove the static ADMIN_API_TOKEN

### DIFF
--- a/apps/idp/app/db/schema.ts
+++ b/apps/idp/app/db/schema.ts
@@ -78,16 +78,16 @@ export const applicationInvitation = sqliteTable(
 export type ApplicationInvitation = typeof applicationInvitation.$inferSelect
 
 /**
- * Scoped API key: a hashed, revocable, optionally-expiring credential that lets
- * an agent or service drive the management API for *one application* with a
- * specific permission set. Replaces the single global ADMIN_API_TOKEN (which
- * stays as the superadmin escape hatch). The plaintext token is shown once at
- * creation and never stored — only its SHA-256 hash and a non-secret prefix
- * (for identification in the UI) are persisted.
+ * Management API key: a hashed, revocable, optionally-expiring credential that
+ * lets an agent or service drive the management API. The plaintext token is
+ * shown once at creation and never stored — only its SHA-256 hash and a
+ * non-secret prefix (for identification in the UI) are persisted.
  *
- * A row with a NULL `application_id` is an IdP-level superadmin key: named,
- * revocable and expiring, and a distinct identity in the audit log — which is
- * what the static ADMIN_API_TOKEN can never be. That token stays as break-glass.
+ * A row with an `application_id` is *scoped*: one application, an explicit
+ * permission set. A row with a NULL `application_id` is an IdP-level **admin
+ * key** — every permission on every app, and a distinct identity in the audit
+ * log. Admin keys are the only superadmin credential there is; break-glass
+ * recovery is to insert one such row by hand (see the client README).
  */
 export const apiKey = sqliteTable(
   "api_key",
@@ -196,7 +196,7 @@ export const auditLog = sqliteTable(
     applicationId: text("application_id"),
     // The human actor's user id when there is one; null for machine callers.
     userId: text("user_id"),
-    // Principal descriptor: "user:<id>" | "apikey:<id>" | "superadmin-token".
+    // Principal descriptor: "user:<id>" | "adminkey:<id>" | "apikey:<id>".
     actor: text("actor"),
     oldData: text("old_data", { mode: "json" }),
     newData: text("new_data", { mode: "json" }),

--- a/apps/idp/app/lib/api-keys.server.ts
+++ b/apps/idp/app/lib/api-keys.server.ts
@@ -193,10 +193,10 @@ export async function revokeApiKey(
 
 /**
  * IdP-level admin keys: `api_key` rows with a NULL `application_id`, which the
- * resolver turns into superadmin callers. They exist so automation stops
- * sharing the one static ADMIN_API_TOKEN — each agent gets its own named,
- * expiring, revocable credential that shows up in the audit log as
- * `adminkey:<id>` instead of an anonymous `superadmin-token`.
+ * resolver turns into superadmin callers. They are the only superadmin
+ * credential the IdP accepts over the wire, so automation never shares one
+ * anonymous secret — each agent gets its own named, expiring, revocable key
+ * that shows up in the audit log as `adminkey:<id>`.
  */
 
 /** Superadmin-only gate, throwing the same 403 shape `assertCan` does. */
@@ -270,7 +270,7 @@ export async function createAdminKey(
     keyHash,
     // Meaningless for an admin key — see listAdminKeys.
     permissions: [],
-    // Null when the static token or another admin key mints this one.
+    // Null when another admin key (rather than a signed-in human) mints this one.
     createdByUserId: caller.userId,
     expiresAt,
   })

--- a/apps/idp/app/lib/audit.server.ts
+++ b/apps/idp/app/lib/audit.server.ts
@@ -21,7 +21,7 @@ export const IDP_AUDIT_SCOPE = "__idp__"
 export type Actor = {
   /** Human user id, when there is one. Null for machine callers. */
   userId: string | null
-  /** Descriptor: "user:<id>" | "apikey:<id>" | "adminkey:<id>" | "superadmin-token". */
+  /** Descriptor: "user:<id>" | "adminkey:<id>" | "apikey:<id>". */
   label: string
 }
 

--- a/apps/idp/app/lib/caller.server.ts
+++ b/apps/idp/app/lib/caller.server.ts
@@ -26,10 +26,10 @@ export type Caller = {
   kind: "superadmin" | "user" | "key"
   /** How the caller authenticated. Only the resolver should ever branch on it. */
   via: "session" | "token"
-  /** Human identity, when there is one. Null for keys and the static token. */
+  /** Human identity, when there is one. Null for keys. */
   userId: string | null
   email: string | null
-  /** Scoped management key identity. Null for humans and the static token. */
+  /** Management key identity — admin key or scoped key. Null for humans. */
   keyId: string | null
   /** The app a scoped key is bound to. Null means not app-bound. */
   applicationId: string | null
@@ -38,10 +38,11 @@ export type Caller = {
   /** Effective management permissions on `app` — for the UI to decide what to render. */
   permissionsFor(app: string): Promise<AppPermission[]>
   /**
-   * Audit identity. Labels: "user:<id>" | "apikey:<id>" | "adminkey:<id>" |
-   * "superadmin-token". A superadmin via session is "user:<id>" (they're a real
-   * person); an IdP-level key is "adminkey:<id>", so every superadmin action is
-   * attributable to one named, revocable credential.
+   * Audit identity. Labels: "user:<id>" | "adminkey:<id>" | "apikey:<id>".
+   * A superadmin via session is "user:<id>" (they're a real person); an
+   * IdP-level key is "adminkey:<id>". Every superadmin action is therefore
+   * attributable to one named, revocable credential — there is no anonymous
+   * superadmin left.
    */
   actor: Actor
 }
@@ -66,42 +67,35 @@ function extractBearer(request: Request): string | null {
   return match ? match[1].trim() : null
 }
 
-/** Constant-time string compare (avoids leaking the admin token via timing). */
-function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false
-  let mismatch = 0
-  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
-  return mismatch === 0
-}
-
 /** Keep only catalog permissions (the catalog may have shrunk since the grant). */
 function sanitizePermissions(permissions: string[]): AppPermission[] {
   return permissions.filter(isAppPermission)
 }
 
-/** Every permission, every app. Used by all three superadmin flavours. */
-function superadminCaller(input: {
-  via: "session" | "token"
-  userId: string | null
-  email: string | null
-  /** Set for an IdP-level admin key, so the audit trail names the credential. */
-  keyId?: string | null
-}): Caller {
-  const keyId = input.keyId ?? null
+/**
+ * Where a superadmin came from. A union rather than nullable fields because
+ * every superadmin now *has* an identity — an allowlisted human or a named
+ * admin key — and the type is what guarantees the audit label can be built.
+ */
+type SuperadminOrigin =
+  | { via: "session"; userId: string; email: string }
+  | { via: "token"; keyId: string }
+
+/** Every permission, every app. Used by both superadmin flavours. */
+function superadminCaller(origin: SuperadminOrigin): Caller {
   return {
     kind: "superadmin",
-    via: input.via,
-    userId: input.userId,
-    email: input.email,
-    keyId,
+    via: origin.via,
+    userId: origin.via === "session" ? origin.userId : null,
+    email: origin.via === "session" ? origin.email : null,
+    keyId: origin.via === "token" ? origin.keyId : null,
     applicationId: null,
     can: async () => true,
     permissionsFor: async () => [...APP_PERMISSIONS],
-    actor: input.userId
-      ? { userId: input.userId, label: `user:${input.userId}` }
-      : keyId
-        ? { userId: null, label: `adminkey:${keyId}` }
-        : { userId: null, label: "superadmin-token" },
+    actor:
+      origin.via === "session"
+        ? { userId: origin.userId, label: `user:${origin.userId}` }
+        : { userId: null, label: `adminkey:${origin.keyId}` },
   }
 }
 
@@ -189,10 +183,10 @@ async function keyCaller(ctx: BaseServiceContext, token: string): Promise<Caller
       }),
     )
 
-  // No app scope ⇒ IdP-level key: same authority as the static token, but it
-  // carries an identity the audit log can name and an admin can revoke.
+  // No app scope ⇒ IdP-level admin key: full superadmin authority, carrying an
+  // identity the audit log can name and an admin can revoke.
   if (row.applicationId === null) {
-    return superadminCaller({ via: "token", userId: null, email: null, keyId: row.id })
+    return superadminCaller({ via: "token", keyId: row.id })
   }
 
   const granted = sanitizePermissions(row.permissions ?? [])
@@ -225,16 +219,8 @@ export async function resolveCaller(
 ): Promise<Caller | null> {
   const token = extractBearer(request)
   if (token) {
-    const superToken = ctx.getAppEnv("ADMIN_API_TOKEN")
-    // Break-glass only: the static token is one shared secret with no name, no
-    // expiry and no revoke short of a redeploy, so it audits as
-    // "superadmin-token" and nothing more. Day-to-day automation should hold an
-    // admin key (POST /api/v1/admin-keys) — attributable and revocable.
-    // Compared without a DB round-trip, so it still works if the DB is down.
-    if (superToken && timingSafeEqual(token, superToken)) {
-      return superadminCaller({ via: "token", userId: null, email: null })
-    }
-    // Only opaque keys we issued are worth a lookup.
+    // Every bearer is a key row we issued — there is no env-configured
+    // superadmin secret. Anything without our prefix isn't worth a lookup.
     if (!token.startsWith(TOKEN_PREFIX)) return null
     return keyCaller(ctx, token)
   }

--- a/apps/idp/app/lib/env.ts
+++ b/apps/idp/app/lib/env.ts
@@ -17,8 +17,6 @@ const appEnvSchema = z.object({
 
   // Admin console + management API. Comma-separated allowlist of admin emails.
   ADMIN_EMAILS: z.string().default("hey@willy.im"),
-  // Bearer token for the read-only management API (/api/v1/*). Optional.
-  ADMIN_API_TOKEN: z.string().optional(),
 })
 
 export type AppEnv = z.infer<typeof appEnvSchema>

--- a/apps/idp/app/routes.ts
+++ b/apps/idp/app/routes.ts
@@ -21,7 +21,7 @@ export default [
     route("account", "routes/app/account.tsx"),
   ]),
 
-  // Management API (Bearer: superadmin ADMIN_API_TOKEN or scoped API key) + docs.
+  // Management API (Bearer: an IdP-level admin key or a per-app scoped key) + docs.
   // Cross-app reads (superadmin only):
   route("api/v1/applications", "routes/api/applications.ts"),
   // Application lifecycle — registration, patch, delete, secret rotation. Every
@@ -32,8 +32,8 @@ export default [
     "routes/api/applications.$clientId.rotate-secret.ts",
   ),
   // IdP-level admin keys — named, expiring, revocable superadmin credentials.
-  // One per agent, so the audit log names who acted; the static ADMIN_API_TOKEN
-  // stays as break-glass.
+  // One per agent, so the audit log names who acted. These are the only way to
+  // reach a cross-app endpoint.
   route("api/v1/admin-keys", "routes/api/admin-keys.ts"),
   route("api/v1/admin-keys/:id", "routes/api/admin-keys.$id.ts"),
   route("api/v1/users", "routes/api/users.ts"),

--- a/apps/idp/test/admin-keys.test.ts
+++ b/apps/idp/test/admin-keys.test.ts
@@ -15,12 +15,12 @@ import * as adminKeyRoute from "../app/routes/api/admin-keys"
 import * as adminKeyIdRoute from "../app/routes/api/admin-keys.$id"
 import {
   bearerRequest,
+  bootstrapAdminKey,
   createApplication,
   createUser,
   fakeUserCaller,
   mintAdminKey,
   mintApiKey,
-  tokenSuperadmin,
 } from "./helpers/fixtures"
 import { createTestHarness, type TestHarness } from "./helpers/harness"
 
@@ -29,8 +29,6 @@ import { createTestHarness, type TestHarness } from "./helpers/harness"
  * "the minted token comes back out of `resolveCaller` as a superadmin with a
  * name" — so most of these mint a key and then present it like a client would.
  */
-
-const ADMIN_TOKEN = "super-secret-admin-token"
 
 function authStub(user: { id: string; email: string } | null): AuthService {
   return {
@@ -51,24 +49,28 @@ async function thrown(fn: () => Promise<unknown>): Promise<Response | null> {
 
 describe("admin keys", () => {
   let h: TestHarness
+  /**
+   * The break-glass key, written straight into `api_key` — the documented way
+   * back in when every admin key is lost, and the only bootstrap there is now
+   * that no static token exists.
+   */
+  let root: { id: string; name: string; token: string; caller: Caller }
+
   beforeEach(async () => {
-    h = createTestHarness({
-      env: { ADMIN_EMAILS: "super@willy.im", ADMIN_API_TOKEN: ADMIN_TOKEN },
-    })
+    h = createTestHarness({ env: { ADMIN_EMAILS: "super@willy.im" } })
+    root = await bootstrapAdminKey(h.ctx)
     await createApplication(h.ctx, { app: "acme" })
   })
   afterEach(() => h.close())
 
-  /** The caller the static break-glass token resolves to, via the real resolver. */
-  const staticTokenCaller = async () =>
-    (await resolveCaller(bearerRequest(ADMIN_TOKEN), h.ctx, authStub(null)))!
-
   const present = (token: string) => resolveCaller(bearerRequest(token), h.ctx, authStub(null))
+
+  /** Everything the bootstrap key isn't — the listing always contains it too. */
+  const minted = (keys: { name: string }[]) => keys.filter((k) => k.name !== root.name)
 
   describe("minting and presenting", () => {
     it("mints a key the resolver accepts as a named superadmin", async () => {
-      const root = await staticTokenCaller()
-      const created = await createAdminKey(h.ctx, root, { name: "Agent alpha" })
+      const created = await createAdminKey(h.ctx, root.caller, { name: "Agent alpha" })
       expect(created.token.startsWith("wim_")).toBe(true)
       expect(created.prefix).toBe(created.token.slice(0, 12))
 
@@ -82,7 +84,7 @@ describe("admin keys", () => {
     })
 
     it("lets an admin key mint another admin key", async () => {
-      const first = await mintAdminKey(h.ctx, { name: "Agent alpha" })
+      const first = await mintAdminKey(h.ctx, { name: "Agent alpha" }, root.caller)
       const asFirst = (await present(first.token))!
 
       const second = await createAdminKey(h.ctx, asFirst, { name: "Agent beta" })
@@ -92,44 +94,44 @@ describe("admin keys", () => {
     })
 
     it("lists admin keys without ever exposing a hash", async () => {
-      await mintAdminKey(h.ctx, { name: "Agent alpha" })
-      const keys = await listAdminKeys(h.ctx, await staticTokenCaller())
-      expect(keys).toHaveLength(1)
-      expect(keys[0]).toMatchObject({ name: "Agent alpha", status: "active", permissions: [] })
+      await mintAdminKey(h.ctx, { name: "Agent alpha" }, root.caller)
+      const keys = await listAdminKeys(h.ctx, root.caller)
+      expect(minted(keys)).toMatchObject([
+        { name: "Agent alpha", status: "active", permissions: [] },
+      ])
       expect(JSON.stringify(keys)).not.toContain("keyHash")
     })
 
     it("keeps admin keys out of an app's key list", async () => {
-      await mintAdminKey(h.ctx)
-      await mintApiKey(h.ctx, { app: "acme", name: "Scoped" })
-      const appKeys = await listApiKeys(h.ctx, tokenSuperadmin(), "acme")
+      await mintAdminKey(h.ctx, {}, root.caller)
+      await mintApiKey(h.ctx, { app: "acme", name: "Scoped" }, root.caller)
+      const appKeys = await listApiKeys(h.ctx, root.caller, "acme")
       expect(appKeys.map((k) => k.name)).toEqual(["Scoped"])
     })
   })
 
   describe("revocation and expiry", () => {
     it("stops authenticating once revoked", async () => {
-      const { token, id } = await mintAdminKey(h.ctx)
+      const { token, id } = await mintAdminKey(h.ctx, {}, root.caller)
       expect(await present(token)).not.toBeNull()
 
-      expect(await revokeAdminKey(h.ctx, await staticTokenCaller(), id)).toEqual({ ok: true })
+      expect(await revokeAdminKey(h.ctx, root.caller, id)).toEqual({ ok: true })
       expect(await present(token)).toBeNull()
     })
 
     it("is idempotent on a second revoke", async () => {
-      const { id } = await mintAdminKey(h.ctx)
-      const root = await staticTokenCaller()
-      await revokeAdminKey(h.ctx, root, id)
-      expect(await revokeAdminKey(h.ctx, root, id)).toEqual({ ok: true })
+      const { id } = await mintAdminKey(h.ctx, {}, root.caller)
+      await revokeAdminKey(h.ctx, root.caller, id)
+      expect(await revokeAdminKey(h.ctx, root.caller, id)).toEqual({ ok: true })
     })
 
     it("reports an unknown id as not found", async () => {
-      const res = await revokeAdminKey(h.ctx, await staticTokenCaller(), "nope")
+      const res = await revokeAdminKey(h.ctx, root.caller, "nope")
       expect(res).toEqual({ error: "Key not found." })
     })
 
     it("lets a key revoke itself, loudly", async () => {
-      const { token, id } = await mintAdminKey(h.ctx)
+      const { token, id } = await mintAdminKey(h.ctx, {}, root.caller)
       const self = (await present(token))!
 
       expect(await revokeAdminKey(h.ctx, self, id)).toEqual({ ok: true })
@@ -139,13 +141,17 @@ describe("admin keys", () => {
     })
 
     it("stops authenticating once expired", async () => {
-      const { token } = await mintAdminKey(h.ctx, { expiresAt: new Date(Date.now() - 1000) })
+      const { token } = await mintAdminKey(
+        h.ctx,
+        { expiresAt: new Date(Date.now() - 1000) },
+        root.caller,
+      )
       expect(await present(token)).toBeNull()
     })
 
     it("reports expiry in the listing", async () => {
-      await mintAdminKey(h.ctx, { expiresAt: new Date(Date.now() - 1000) })
-      const [key] = await listAdminKeys(h.ctx, await staticTokenCaller())
+      await mintAdminKey(h.ctx, { expiresAt: new Date(Date.now() - 1000) }, root.caller)
+      const [key] = minted(await listAdminKeys(h.ctx, root.caller))
       expect(key.status).toBe("expired")
     })
   })
@@ -157,7 +163,7 @@ describe("admin keys", () => {
         app: "acme",
         permissions: [...APP_PERMISSIONS],
       })
-      const { id } = await mintAdminKey(h.ctx)
+      const { id } = await mintAdminKey(h.ctx, {}, root.caller)
 
       for (const call of [
         () => listAdminKeys(h.ctx, user),
@@ -171,10 +177,14 @@ describe("admin keys", () => {
     })
 
     it("refuses an app-scoped key holding every app permission", async () => {
-      const scoped = await mintApiKey(h.ctx, { app: "acme", permissions: [...APP_PERMISSIONS] })
+      const scoped = await mintApiKey(
+        h.ctx,
+        { app: "acme", permissions: [...APP_PERMISSIONS] },
+        root.caller,
+      )
       const caller = (await present(scoped.token))!
       expect(caller.kind).toBe("key")
-      const { id } = await mintAdminKey(h.ctx)
+      const { id } = await mintAdminKey(h.ctx, {}, root.caller)
 
       for (const call of [
         () => listAdminKeys(h.ctx, caller),
@@ -186,8 +196,8 @@ describe("admin keys", () => {
     })
 
     it("does not let an app-scoped revoke reach an admin key by id", async () => {
-      const admin = await mintAdminKey(h.ctx)
-      const res = await revokeApiKey(h.ctx, tokenSuperadmin(), { app: "acme", id: admin.id })
+      const admin = await mintAdminKey(h.ctx, {}, root.caller)
+      const res = await revokeApiKey(h.ctx, root.caller, { app: "acme", id: admin.id })
       expect(res).toEqual({ error: "Key not found." })
       // Still very much alive.
       expect(await present(admin.token)).not.toBeNull()
@@ -196,15 +206,20 @@ describe("admin keys", () => {
 
   describe("audit trail", () => {
     it("records the mint under the IdP scope", async () => {
-      const created = await createAdminKey(h.ctx, await staticTokenCaller(), { name: "Agent" })
+      const created = await createAdminKey(h.ctx, root.caller, { name: "Agent" })
       const entries = await listAuditForApp(h.ctx, IDP_AUDIT_SCOPE)
       expect(entries).toMatchObject([
-        { tableName: "api_key", operation: "create", rowId: created.id, actor: "superadmin-token" },
+        {
+          tableName: "api_key",
+          operation: "create",
+          rowId: created.id,
+          actor: `adminkey:${root.id}`,
+        },
       ])
     })
 
     it("names the admin key that acted, not just 'a superadmin'", async () => {
-      const first = await mintAdminKey(h.ctx, { name: "Agent alpha" })
+      const first = await mintAdminKey(h.ctx, { name: "Agent alpha" }, root.caller)
       const asFirst = (await present(first.token))!
       const second = await createAdminKey(h.ctx, asFirst, { name: "Agent beta" })
       await revokeAdminKey(h.ctx, asFirst, second.id)
@@ -217,7 +232,7 @@ describe("admin keys", () => {
     })
 
     it("keeps IdP-level rows out of an app's audit view", async () => {
-      await mintAdminKey(h.ctx)
+      await mintAdminKey(h.ctx, {}, root.caller)
       expect(await listAuditForApp(h.ctx, "acme")).toEqual([])
     })
   })
@@ -265,7 +280,11 @@ describe("admin keys", () => {
     })
 
     it("403s an app-scoped key", async () => {
-      const scoped = await mintApiKey(h.ctx, { app: "acme", permissions: [...APP_PERMISSIONS] })
+      const scoped = await mintApiKey(
+        h.ctx,
+        { app: "acme", permissions: [...APP_PERMISSIONS] },
+        root.caller,
+      )
       const res = await call(adminKeyRoute.loader, {
         request: request("/api/v1/admin-keys", { token: scoped.token }),
       })
@@ -276,7 +295,7 @@ describe("admin keys", () => {
       const res = await call(adminKeyRoute.action, {
         request: request("/api/v1/admin-keys", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: root.token,
           body: { name: "Agent alpha" },
         }),
       })
@@ -287,18 +306,19 @@ describe("admin keys", () => {
       // The token works, and the listing never shows it again.
       expect((await present(body.token))!.keyId).toBe(body.id)
       const list = await call(adminKeyRoute.loader, {
-        request: request("/api/v1/admin-keys", { token: ADMIN_TOKEN }),
+        request: request("/api/v1/admin-keys", { token: root.token }),
       })
       expect(list.status).toBe(200)
       expect(JSON.stringify(list.body)).not.toContain(body.token)
-      expect(list.body).toMatchObject({ keys: [{ id: body.id, name: "Agent alpha" }] })
+      const keys = (list.body as { keys: { id: string; name: string }[] }).keys
+      expect(minted(keys)).toMatchObject([{ id: body.id, name: "Agent alpha" }])
     })
 
     it("422s a body with no name", async () => {
       const res = await call(adminKeyRoute.action, {
         request: request("/api/v1/admin-keys", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: root.token,
           body: { name: "" },
         }),
       })
@@ -306,15 +326,15 @@ describe("admin keys", () => {
     })
 
     it("200s a delete and 404s an unknown id", async () => {
-      const { id } = await mintAdminKey(h.ctx)
+      const { id } = await mintAdminKey(h.ctx, {}, root.caller)
       const ok = await call(adminKeyIdRoute.action, {
-        request: request(`/api/v1/admin-keys/${id}`, { method: "DELETE", token: ADMIN_TOKEN }),
+        request: request(`/api/v1/admin-keys/${id}`, { method: "DELETE", token: root.token }),
         params: { id },
       })
       expect(ok).toMatchObject({ status: 200, body: { ok: true } })
 
       const missing = await call(adminKeyIdRoute.action, {
-        request: request("/api/v1/admin-keys/nope", { method: "DELETE", token: ADMIN_TOKEN }),
+        request: request("/api/v1/admin-keys/nope", { method: "DELETE", token: root.token }),
         params: { id: "nope" },
       })
       expect(missing).toMatchObject({ status: 404, body: { error: "not_found" } })
@@ -322,13 +342,13 @@ describe("admin keys", () => {
 
     it("405s an unsupported method, saying what it does allow", async () => {
       const collection = await call(adminKeyRoute.action, {
-        request: request("/api/v1/admin-keys", { method: "PATCH", token: ADMIN_TOKEN }),
+        request: request("/api/v1/admin-keys", { method: "PATCH", token: root.token }),
       })
       expect(collection.status).toBe(405)
       expect(collection.headers.get("Allow")).toBe("GET, POST")
 
       const item = await call(adminKeyIdRoute.action, {
-        request: request("/api/v1/admin-keys/x", { method: "POST", token: ADMIN_TOKEN }),
+        request: request("/api/v1/admin-keys/x", { method: "POST", token: root.token }),
         params: { id: "x" },
       })
       expect(item.status).toBe(405)

--- a/apps/idp/test/api-keys.test.ts
+++ b/apps/idp/test/api-keys.test.ts
@@ -4,7 +4,7 @@ import { createApiKey, listApiKeys, revokeApiKey } from "../app/lib/api-keys.ser
 import { listAuditForApp } from "../app/lib/audit.server"
 import type { Caller } from "../app/lib/caller.server"
 import { APP_PERMISSIONS } from "../app/lib/permissions"
-import { createUser, fakeUserCaller, tokenSuperadmin } from "./helpers/fixtures"
+import { bootstrapAdminKey, createUser, fakeUserCaller } from "./helpers/fixtures"
 import { createTestHarness, type TestHarness } from "./helpers/harness"
 
 /**
@@ -14,9 +14,12 @@ import { createTestHarness, type TestHarness } from "./helpers/harness"
 describe("scoped management API keys", () => {
   let h: TestHarness
   let creator: { id: string }
+  /** A real IdP-level admin key, resolved through the production resolver. */
+  let root: Caller
 
   beforeEach(async () => {
-    h = createTestHarness({ env: { ADMIN_API_TOKEN: "super-secret-admin-token" } })
+    h = createTestHarness()
+    root = (await bootstrapAdminKey(h.ctx)).caller
     creator = await createUser(h.ctx, { email: "creator@acme.test" })
   })
   afterEach(() => h.close())
@@ -47,7 +50,7 @@ describe("scoped management API keys", () => {
     return res
   }
 
-  const list = (app = "acme") => listApiKeys(h.ctx, tokenSuperadmin(), app)
+  const list = (app = "acme") => listApiKeys(h.ctx, root, app)
 
   it("returns the plaintext token exactly once and never stores it", async () => {
     const { token, prefix, id } = await mintOk()
@@ -84,7 +87,9 @@ describe("scoped management API keys", () => {
 
   it("will not let one app revoke another app's key", async () => {
     const { id } = await mintOk()
-    expect(await revokeApiKey(h.ctx, tokenSuperadmin(), { app: "other", id })).toEqual({ error: "Key not found." })
+    expect(await revokeApiKey(h.ctx, root, { app: "other", id })).toEqual({
+      error: "Key not found.",
+    })
 
     const [listed] = await list()
     expect(listed.id).toBe(id)
@@ -92,7 +97,7 @@ describe("scoped management API keys", () => {
   })
 
   it("accepts a machine caller — the static admin token has no user behind it", async () => {
-    const res = await mint({}, tokenSuperadmin())
+    const res = await mint({}, root)
     if ("error" in res) throw new Error(res.error)
     const [listed] = await list()
     expect(listed.id).toBe(res.id)
@@ -144,7 +149,7 @@ describe("scoped management API keys", () => {
     })
 
     it("lets a superadmin mint anything", async () => {
-      const res = await mint({ permissions: [...APP_PERMISSIONS] }, tokenSuperadmin())
+      const res = await mint({ permissions: [...APP_PERMISSIONS] }, root)
       if ("error" in res) throw new Error(res.error)
 
       const [listed] = await list()

--- a/apps/idp/test/api-routes.test.ts
+++ b/apps/idp/test/api-routes.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import { createApplication } from "../app/lib/admin.server"
 import type { AuthService } from "../app/lib/auth.server"
-import { resolveCaller, type Caller } from "../app/lib/caller.server"
+import type { Caller } from "../app/lib/caller.server"
 import * as applications from "../app/routes/api/applications"
 import * as application from "../app/routes/api/applications.$clientId"
 import * as rotateSecret from "../app/routes/api/applications.$clientId.rotate-secret"
@@ -11,7 +11,7 @@ import * as appKey from "../app/routes/api/apps.$app.keys.$id"
 import * as appMembers from "../app/routes/api/apps.$app.members"
 import * as appPermissions from "../app/routes/api/apps.$app.permissions"
 import * as appUserKeys from "../app/routes/api/apps.$app.user-keys"
-import { createMember, createUser } from "./helpers/fixtures"
+import { bootstrapAdminKey, createMember, createUser } from "./helpers/fixtures"
 import { createTestHarness, type TestHarness } from "./helpers/harness"
 
 /**
@@ -19,8 +19,6 @@ import { createTestHarness, type TestHarness } from "./helpers/harness"
  * handlers are called directly with a Request and a context, which is all a
  * resource route ever touches — no router, no Workers runtime.
  */
-
-const ADMIN_TOKEN = "super-secret-admin-token"
 
 function authStub(user: { id: string; email: string } | null): AuthService {
   return {
@@ -32,7 +30,9 @@ describe("management API routes", () => {
   let h: TestHarness
   let context: Record<string, unknown>
   let acme: { clientId: string; app: string }
+  /** An IdP-level admin key — the only bearer a cross-app endpoint accepts. */
   let root: Caller
+  let adminToken: string
 
   /** Handlers signal failure by throwing a Response; normalise both paths. */
   const call = async (
@@ -56,11 +56,11 @@ describe("management API routes", () => {
     })
 
   beforeEach(async () => {
-    h = createTestHarness({
-      env: { ADMIN_EMAILS: "super@willy.im", ADMIN_API_TOKEN: ADMIN_TOKEN },
-    })
+    h = createTestHarness({ env: { ADMIN_EMAILS: "super@willy.im" } })
     context = { ...h.ctx, services: { auth: authStub(null) }, cloudflare: {} }
-    root = (await resolveCaller(request("/", { token: ADMIN_TOKEN }), h.ctx, authStub(null)))!
+    const bootstrap = await bootstrapAdminKey(h.ctx)
+    adminToken = bootstrap.token
+    root = bootstrap.caller
     const created = await createApplication(h.ctx, root, {
       name: "Acme",
       app: "acme",
@@ -102,7 +102,7 @@ describe("management API routes", () => {
       const res = await call(applications.action, {
         request: request("/api/v1/applications", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { name: "Invoices", app: "invoices", redirectUris: ["https://inv.test/cb"] },
         }),
       })
@@ -115,7 +115,7 @@ describe("management API routes", () => {
       const res = await call(applications.action, {
         request: request("/api/v1/applications", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { name: "Acme 2", app: "acme", redirectUris: ["https://acme.test/cb"] },
         }),
       })
@@ -126,7 +126,7 @@ describe("management API routes", () => {
       const res = await call(applications.action, {
         request: request("/api/v1/applications", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { name: "No key", redirectUris: [] },
         }),
       })
@@ -136,7 +136,7 @@ describe("management API routes", () => {
 
     it("405s a method the resource doesn't serve", async () => {
       const res = await call(applications.action, {
-        request: request("/api/v1/applications", { method: "PUT", token: ADMIN_TOKEN }),
+        request: request("/api/v1/applications", { method: "PUT", token: adminToken }),
       })
       expect(res).toEqual({ status: 405, body: { error: "method_not_allowed" } })
     })
@@ -164,7 +164,7 @@ describe("management API routes", () => {
 
     it("404s an unknown client id", async () => {
       const res = await call(application.loader, {
-        request: request("/api/v1/applications/nope", { token: ADMIN_TOKEN }),
+        request: request("/api/v1/applications/nope", { token: adminToken }),
         params: { clientId: "nope" },
       })
       expect(res).toEqual({ status: 404, body: { error: "not_found" } })
@@ -174,7 +174,7 @@ describe("management API routes", () => {
       const patched = await call(application.action, {
         request: request(`/api/v1/applications/${acme.clientId}`, {
           method: "PATCH",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { name: "Acme Inc", allowSignup: true },
         }),
         params: { clientId: acme.clientId },
@@ -185,7 +185,7 @@ describe("management API routes", () => {
       const deleted = await call(application.action, {
         request: request(`/api/v1/applications/${acme.clientId}`, {
           method: "DELETE",
-          token: ADMIN_TOKEN,
+          token: adminToken,
         }),
         params: { clientId: acme.clientId },
       })
@@ -196,7 +196,7 @@ describe("management API routes", () => {
       const res = await call(application.action, {
         request: request(`/api/v1/applications/${acme.clientId}`, {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
         }),
         params: { clientId: acme.clientId },
       })
@@ -209,7 +209,7 @@ describe("management API routes", () => {
       const res = await call(rotateSecret.action, {
         request: request(`/api/v1/applications/${acme.clientId}/rotate-secret`, {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
         }),
         params: { clientId: acme.clientId },
       })
@@ -231,7 +231,7 @@ describe("management API routes", () => {
     it("405s GET-shaped use", async () => {
       const res = await call(rotateSecret.action, {
         request: request(`/api/v1/applications/${acme.clientId}/rotate-secret`, {
-          token: ADMIN_TOKEN,
+          token: adminToken,
         }),
         params: { clientId: acme.clientId },
       })
@@ -244,7 +244,7 @@ describe("management API routes", () => {
       const res = await call(appPermissions.action, {
         request: request("/api/v1/apps/acme/permissions", {
           method: "PUT",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { permissions: ["invoices:read", "invoices:write"] },
         }),
         params: { app: "acme" },
@@ -259,7 +259,7 @@ describe("management API routes", () => {
       const res = await call(appPermissions.action, {
         request: request("/api/v1/apps/ghost/permissions", {
           method: "PUT",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { permissions: [] },
         }),
         params: { app: "ghost" },
@@ -271,7 +271,7 @@ describe("management API routes", () => {
       const res = await call(appPermissions.action, {
         request: request("/api/v1/apps/acme/permissions", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
         }),
         params: { app: "acme" },
       })
@@ -284,7 +284,7 @@ describe("management API routes", () => {
       const created = await call(appKeys.action, {
         request: request("/api/v1/apps/acme/keys", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { name: "CI", permissions: ["member:read"] },
         }),
         params: { app: "acme" },
@@ -294,7 +294,7 @@ describe("management API routes", () => {
       expect(token.startsWith("wim_")).toBe(true)
 
       const listed = await call(appKeys.loader, {
-        request: request("/api/v1/apps/acme/keys", { token: ADMIN_TOKEN }),
+        request: request("/api/v1/apps/acme/keys", { token: adminToken }),
         params: { app: "acme" },
       })
       expect(listed.status).toBe(200)
@@ -327,7 +327,7 @@ describe("management API routes", () => {
 
     it("405s DELETE on the collection", async () => {
       const res = await call(appKeys.action, {
-        request: request("/api/v1/apps/acme/keys", { method: "DELETE", token: ADMIN_TOKEN }),
+        request: request("/api/v1/apps/acme/keys", { method: "DELETE", token: adminToken }),
         params: { app: "acme" },
       })
       expect(res).toEqual({ status: 405, body: { error: "method_not_allowed" } })
@@ -397,7 +397,7 @@ describe("management API routes", () => {
       const created = await call(appKeys.action, {
         request: request("/api/v1/apps/acme/keys", {
           method: "POST",
-          token: ADMIN_TOKEN,
+          token: adminToken,
           body: { name: "CI", permissions: ["member:read"] },
         }),
         params: { app: "acme" },
@@ -410,7 +410,7 @@ describe("management API routes", () => {
       const res = await call(appKey.action, {
         request: request(`/api/v1/apps/acme/keys/${id}`, {
           method: "DELETE",
-          token: ADMIN_TOKEN,
+          token: adminToken,
         }),
         params: { app: "acme", id },
       })
@@ -421,7 +421,7 @@ describe("management API routes", () => {
       const res = await call(appKey.action, {
         request: request("/api/v1/apps/acme/keys/ghost", {
           method: "DELETE",
-          token: ADMIN_TOKEN,
+          token: adminToken,
         }),
         params: { app: "acme", id: "ghost" },
       })
@@ -430,7 +430,7 @@ describe("management API routes", () => {
 
     it("405s GET", async () => {
       const res = await call(appKey.action, {
-        request: request("/api/v1/apps/acme/keys/whatever", { token: ADMIN_TOKEN }),
+        request: request("/api/v1/apps/acme/keys/whatever", { token: adminToken }),
         params: { app: "acme", id: "whatever" },
       })
       expect(res).toEqual({ status: 405, body: { error: "method_not_allowed" } })

--- a/apps/idp/test/applications.test.ts
+++ b/apps/idp/test/applications.test.ts
@@ -16,15 +16,13 @@ import { listAuditForApp } from "../app/lib/audit.server"
 import type { AuthService } from "../app/lib/auth.server"
 import { resolveCaller, type Caller } from "../app/lib/caller.server"
 import { hashClientSecret } from "../app/lib/client-secret.server"
-import { bearerRequest, createMember, createUser } from "./helpers/fixtures"
+import { bootstrapAdminKey, createMember, createUser } from "./helpers/fixtures"
 import { createTestHarness, type TestHarness } from "./helpers/harness"
 
 /**
  * Application lifecycle driven entirely by a bearer caller — the point of the
  * refactor. Nothing here touches a cookie session or a better-auth endpoint.
  */
-
-const ADMIN_TOKEN = "super-secret-admin-token"
 
 /** The resolver only needs `api.getSession`; sessions aren't what's under test. */
 function authStub(user: { id: string; email: string } | null): AuthService {
@@ -45,14 +43,12 @@ async function thrownStatus(fn: () => Promise<unknown>): Promise<number> {
 
 describe("application lifecycle", () => {
   let h: TestHarness
-  /** The static ADMIN_API_TOKEN, resolved through the real front-door path. */
+  /** An IdP-level admin key, resolved through the real front-door path. */
   let root: Caller
 
   beforeEach(async () => {
-    h = createTestHarness({
-      env: { ADMIN_EMAILS: "super@willy.im", ADMIN_API_TOKEN: ADMIN_TOKEN },
-    })
-    root = (await resolveCaller(bearerRequest(ADMIN_TOKEN), h.ctx, authStub(null)))!
+    h = createTestHarness({ env: { ADMIN_EMAILS: "super@willy.im" } })
+    root = (await bootstrapAdminKey(h.ctx)).caller
   })
   afterEach(() => h.close())
 
@@ -176,7 +172,7 @@ describe("application lifecycle", () => {
         tableName: "oauth_client",
         operation: "create",
         rowId: clientId,
-        actor: "superadmin-token",
+        actor: `adminkey:${root.keyId}`,
         userId: null,
       })
     })
@@ -252,7 +248,7 @@ describe("application lifecycle", () => {
 
       const entries = await listAuditForApp(h.ctx, "acme")
       expect(entries.map((e) => e.operation)).toEqual(["delete", "update", "update", "create"])
-      expect(entries.every((e) => e.actor === "superadmin-token")).toBe(true)
+      expect(entries.every((e) => e.actor === `adminkey:${root.keyId}`)).toBe(true)
       expect(entries.every((e) => e.tableName === "oauth_client")).toBe(true)
     })
   })

--- a/apps/idp/test/caller.test.ts
+++ b/apps/idp/test/caller.test.ts
@@ -14,12 +14,12 @@ import {
 import { APP_PERMISSIONS } from "../app/lib/permissions"
 import {
   bearerRequest,
+  bootstrapAdminKey,
   createApplication,
   createMember,
   createUser,
   mintAdminKey,
   mintApiKey,
-  tokenSuperadmin,
 } from "./helpers/fixtures"
 import { createTestHarness, type TestHarness } from "./helpers/harness"
 
@@ -48,44 +48,50 @@ async function thrown(fn: () => Promise<unknown>): Promise<Response | null> {
   }
 }
 
-const ADMIN_TOKEN = "super-secret-admin-token"
-
 describe("resolveCaller", () => {
   let h: TestHarness
+  /** An IdP-level admin key — the only superadmin credential a bearer can be. */
+  let root: { id: string; token: string; caller: Caller }
   beforeEach(async () => {
-    h = createTestHarness({
-      env: { ADMIN_EMAILS: "super@willy.im", ADMIN_API_TOKEN: ADMIN_TOKEN },
-    })
+    h = createTestHarness({ env: { ADMIN_EMAILS: "super@willy.im" } })
+    root = await bootstrapAdminKey(h.ctx)
     await createApplication(h.ctx, { app: "acme", permissions: ["invoices:read"] })
   })
   afterEach(() => h.close())
 
   const mint = (overrides: Partial<Parameters<typeof mintApiKey>[1]> = {}) =>
-    mintApiKey(h.ctx, { app: "acme", permissions: ["member:read", "member:invite"], ...overrides })
+    mintApiKey(
+      h.ctx,
+      { app: "acme", permissions: ["member:read", "member:invite"], ...overrides },
+      root.caller,
+    )
 
   it("returns null when there is neither a bearer token nor a session", async () => {
     expect(await resolveCaller(consoleRequest, h.ctx, authStub(null))).toBeNull()
   })
 
-  it("resolves the static admin token to a superadmin with no human identity", async () => {
-    const caller = await resolveCaller(bearerRequest(ADMIN_TOKEN), h.ctx, authStub(null))
-
-    expect(caller!.kind).toBe("superadmin")
-    expect(caller!.via).toBe("token")
-    expect(caller!.userId).toBeNull()
-    expect(caller!.email).toBeNull()
-    expect(caller!.keyId).toBeNull()
-    expect(caller!.applicationId).toBeNull()
-    expect(caller!.actor).toEqual({ userId: null, label: "superadmin-token" })
-    expect(await caller!.can("literally-anything", "app:delete")).toBe(true)
-  })
-
   it("prefers the bearer token over the session cookie", async () => {
     const user = await createUser(h.ctx, { email: "member@acme.test" })
 
-    const caller = await resolveCaller(bearerRequest(ADMIN_TOKEN), h.ctx, authStub(user))
+    const caller = await resolveCaller(bearerRequest(root.token), h.ctx, authStub(user))
     expect(caller!.kind).toBe("superadmin")
     expect(caller!.via).toBe("token")
+    expect(caller!.keyId).toBe(root.id)
+  })
+
+  it("has no env-based backdoor: a bearer that is not a wim_ key is nobody", async () => {
+    // The static superadmin secret is gone. Every accepted bearer is now a key
+    // row we issued, so a token that happens to equal an environment value —
+    // including one an older build honoured — buys the caller nothing.
+    const secret = "super-secret-admin-token"
+    process.env.LEGACY_SUPERADMIN_TOKEN = secret
+    try {
+      for (const guess of [secret, process.env.BETTER_AUTH_SECRET!, process.env.ADMIN_EMAILS!]) {
+        expect(await resolveCaller(bearerRequest(guess), h.ctx, authStub(null))).toBeNull()
+      }
+    } finally {
+      delete process.env.LEGACY_SUPERADMIN_TOKEN
+    }
   })
 
   it("refuses a bad bearer instead of falling through to a valid cookie", async () => {
@@ -210,7 +216,7 @@ describe("resolveCaller", () => {
 
   it("refuses a revoked key", async () => {
     const { token, id } = await mint()
-    await revokeApiKey(h.ctx, tokenSuperadmin(), { app: "acme", id })
+    await revokeApiKey(h.ctx, root.caller, { app: "acme", id })
     expect(await resolveCaller(bearerRequest(token), h.ctx, authStub(null))).toBeNull()
   })
 
@@ -220,7 +226,7 @@ describe("resolveCaller", () => {
   })
 
   it("resolves an unscoped key to a superadmin that the audit log can name", async () => {
-    const { token, id } = await mintAdminKey(h.ctx, { name: "Agent alpha" })
+    const { token, id } = await mintAdminKey(h.ctx, { name: "Agent alpha" }, root.caller)
 
     const caller = await resolveCaller(bearerRequest(token), h.ctx, authStub(null))
     expect(caller!.kind).toBe("superadmin")
@@ -229,14 +235,14 @@ describe("resolveCaller", () => {
     expect(caller!.applicationId).toBeNull()
     expect(caller!.userId).toBeNull()
     expect(caller!.email).toBeNull()
-    // The whole difference from the static token: a name in the trail.
+    // The point of an admin key: a name in the trail.
     expect(caller!.actor).toEqual({ userId: null, label: `adminkey:${id}` })
     expect(await caller!.can("literally-anything", "app:delete")).toBe(true)
     expect(await caller!.permissionsFor("literally-anything")).toEqual([...APP_PERMISSIONS])
   })
 
   it("bumps lastUsedAt on an admin key too", async () => {
-    const { token, id } = await mintAdminKey(h.ctx)
+    const { token, id } = await mintAdminKey(h.ctx, {}, root.caller)
     await resolveCaller(bearerRequest(token), h.ctx, authStub(null))
 
     const [row] = await h.ctx.db
@@ -247,23 +253,27 @@ describe("resolveCaller", () => {
   })
 
   it("refuses a revoked admin key", async () => {
-    const { token, id } = await mintAdminKey(h.ctx)
-    await revokeAdminKey(h.ctx, tokenSuperadmin(), id)
+    const { token, id } = await mintAdminKey(h.ctx, {}, root.caller)
+    await revokeAdminKey(h.ctx, root.caller, id)
     expect(await resolveCaller(bearerRequest(token), h.ctx, authStub(null))).toBeNull()
   })
 
   it("refuses an expired admin key", async () => {
-    const { token } = await mintAdminKey(h.ctx, { expiresAt: new Date(Date.now() - 1000) })
+    const { token } = await mintAdminKey(
+      h.ctx,
+      { expiresAt: new Date(Date.now() - 1000) },
+      root.caller,
+    )
     expect(await resolveCaller(bearerRequest(token), h.ctx, authStub(null))).toBeNull()
   })
 })
 
 describe("authorize", () => {
   let h: TestHarness
+  let root: { id: string; token: string; caller: Caller }
   beforeEach(async () => {
-    h = createTestHarness({
-      env: { ADMIN_EMAILS: "super@willy.im", ADMIN_API_TOKEN: ADMIN_TOKEN },
-    })
+    h = createTestHarness({ env: { ADMIN_EMAILS: "super@willy.im" } })
+    root = await bootstrapAdminKey(h.ctx)
     await createApplication(h.ctx, { app: "acme" })
   })
   afterEach(() => h.close())
@@ -284,11 +294,15 @@ describe("authorize", () => {
     const superadmin = await createUser(h.ctx, { email: "super@willy.im" })
     const boss = await createUser(h.ctx, { email: "boss@acme.test" })
     await createMember(h.ctx, { app: "acme", userId: boss.id, role: "admin" })
-    const key = await mintApiKey(h.ctx, { app: "acme", permissions: [...APP_PERMISSIONS] })
+    const key = await mintApiKey(
+      h.ctx,
+      { app: "acme", permissions: [...APP_PERMISSIONS] },
+      root.caller,
+    )
 
     const need = { superadmin: true } as const
     const bySession = await resolveCaller(consoleRequest, h.ctx, authStub(superadmin))
-    const byToken = await resolveCaller(bearerRequest(ADMIN_TOKEN), h.ctx, authStub(null))
+    const byToken = await resolveCaller(bearerRequest(root.token), h.ctx, authStub(null))
     const appAdmin = await resolveCaller(consoleRequest, h.ctx, authStub(boss))
     const scoped = await resolveCaller(bearerRequest(key.token), h.ctx, authStub(null))
 
@@ -317,16 +331,16 @@ describe("authorize", () => {
 
 describe("requireApiCaller", () => {
   let h: TestHarness
+  let root: { id: string; token: string; caller: Caller }
   beforeEach(async () => {
-    h = createTestHarness({
-      env: { ADMIN_EMAILS: "super@willy.im", ADMIN_API_TOKEN: ADMIN_TOKEN },
-    })
+    h = createTestHarness({ env: { ADMIN_EMAILS: "super@willy.im" } })
+    root = await bootstrapAdminKey(h.ctx)
     await createApplication(h.ctx, { app: "acme" })
   })
   afterEach(() => h.close())
 
   const auth = authStub(null)
-  const mint = () => mintApiKey(h.ctx, { app: "acme", permissions: ["member:read"] })
+  const mint = () => mintApiKey(h.ctx, { app: "acme", permissions: ["member:read"] }, root.caller)
 
   it("401s without a bearer token", async () => {
     const res = await thrown(() =>
@@ -368,17 +382,18 @@ describe("requireApiCaller", () => {
     expect(res!.status).toBe(403)
   })
 
-  it("reserves cross-app endpoints for the superadmin token", async () => {
+  it("reserves cross-app endpoints for admin keys", async () => {
     const { token } = await mint()
     const denied = await thrown(() =>
       requireApiCaller(bearerRequest(token), h.ctx, auth, { superadmin: true }),
     )
     expect(denied!.status).toBe(403)
 
-    const allowed = await requireApiCaller(bearerRequest(ADMIN_TOKEN), h.ctx, auth, {
+    const allowed = await requireApiCaller(bearerRequest(root.token), h.ctx, auth, {
       superadmin: true,
     })
     expect(allowed.kind).toBe("superadmin")
+    expect(allowed.keyId).toBe(root.id)
   })
 })
 

--- a/apps/idp/test/helpers/fixtures.ts
+++ b/apps/idp/test/helpers/fixtures.ts
@@ -1,7 +1,13 @@
 import * as schema from "../../app/db/schema"
-import { createAdminKey, createApiKey } from "../../app/lib/api-keys.server"
-import type { Caller } from "../../app/lib/caller.server"
-import { APP_PERMISSIONS, type AppPermission } from "../../app/lib/permissions"
+import {
+  createAdminKey,
+  createApiKey,
+  generateToken,
+  hashToken,
+} from "../../app/lib/api-keys.server"
+import type { AuthService } from "../../app/lib/auth.server"
+import { resolveCaller, type Caller } from "../../app/lib/caller.server"
+import type { AppPermission } from "../../app/lib/permissions"
 import type { BaseServiceContext } from "../../app/lib/services"
 
 /**
@@ -131,23 +137,39 @@ export function bearerRequest(token: string, url = "https://idp.willy.im/api/v1/
   return new Request(url, { headers: { authorization: `Bearer ${token}` } })
 }
 
+/** The resolver only reads `api.getSession`; a bearer caller never has one. */
+const sessionlessAuth = {
+  api: { getSession: async () => null },
+} as unknown as AuthService
+
 /**
- * The caller the static ADMIN_API_TOKEN resolves to: every permission on every
- * app, no human identity. Built literally so tests that only need *a* caller
- * don't have to stand up a request + auth stub.
+ * The break-glass admin key, written straight into `api_key` the way real
+ * recovery does: an unscoped row (`application_id` NULL) whose `key_hash` is
+ * the SHA-256 of a token we generated. Everything a test needs to act as a
+ * superadmin comes back — the plaintext bearer, a Request carrying it, and the
+ * Caller the *real* resolver builds from it, so no test hand-rolls a superadmin
+ * object that production could never produce.
  */
-export function tokenSuperadmin(): Caller {
-  return {
-    kind: "superadmin",
-    via: "token",
-    userId: null,
-    email: null,
-    keyId: null,
+export async function bootstrapAdminKey(
+  ctx: BaseServiceContext,
+  input: { name?: string; expiresAt?: Date | null } = {},
+): Promise<{ id: string; name: string; token: string; request: Request; caller: Caller }> {
+  const token = generateToken()
+  const id = `adminkey_${uniq()}`
+  const name = input.name ?? "Bootstrap key"
+  await ctx.db.insert(schema.apiKey).values({
+    id,
     applicationId: null,
-    can: async () => true,
-    permissionsFor: async () => [...APP_PERMISSIONS],
-    actor: { userId: null, label: "superadmin-token" },
-  }
+    name,
+    prefix: token.slice(0, 12),
+    keyHash: await hashToken(token),
+    permissions: [],
+    expiresAt: input.expiresAt ?? null,
+  })
+  const request = bearerRequest(token)
+  const caller = await resolveCaller(request, ctx, sessionlessAuth)
+  if (!caller) throw new Error("bootstrapAdminKey: the resolver rejected the key it was handed")
+  return { id, name, token, request, caller }
 }
 
 /** A signed-in human caller with an explicit permission set on one app. */
@@ -170,11 +192,11 @@ export function fakeUserCaller(input: {
   }
 }
 
-/** Mints a scoped key as the superadmin token, unwrapping the error union. */
+/** Mints a scoped key as `caller`, unwrapping the error union. */
 export async function mintApiKey(
   ctx: BaseServiceContext,
   input: { app: string; name?: string; permissions?: string[]; expiresAt?: Date | null },
-  caller: Caller = tokenSuperadmin(),
+  caller: Caller,
 ) {
   const res = await createApiKey(ctx, caller, {
     app: input.app,
@@ -186,11 +208,11 @@ export async function mintApiKey(
   return res
 }
 
-/** Mints an IdP-level admin key (unscoped ⇒ superadmin) as the static token. */
+/** Mints an IdP-level admin key (unscoped ⇒ superadmin) through the service. */
 export async function mintAdminKey(
   ctx: BaseServiceContext,
-  input: { name?: string; expiresAt?: Date | null } = {},
-  caller: Caller = tokenSuperadmin(),
+  input: { name?: string; expiresAt?: Date | null },
+  caller: Caller,
 ) {
   return createAdminKey(ctx, caller, {
     name: input.name ?? "Agent alpha",

--- a/apps/idp/test/helpers/harness.ts
+++ b/apps/idp/test/helpers/harness.ts
@@ -61,7 +61,7 @@ export type TestHarness = {
 }
 
 export type TestHarnessOptions = {
-  /** Overrides for the env `getAppEnv` reads (ADMIN_EMAILS, ADMIN_API_TOKEN, …). */
+  /** Overrides for the env `getAppEnv` reads (ADMIN_EMAILS, LOG_LEVEL, …). */
   env?: Record<string, string>
 }
 

--- a/apps/idp/test/members.test.ts
+++ b/apps/idp/test/members.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import * as schema from "../app/db/schema"
 import { listAuditForApp } from "../app/lib/audit.server"
+import type { Caller } from "../app/lib/caller.server"
 import {
   addOrInviteAppMember,
   claimInvitationsForUser,
@@ -13,11 +14,11 @@ import {
   updateAppMember,
 } from "../app/lib/members.server"
 import {
+  bootstrapAdminKey,
   createApplication,
   createMember,
   createUser,
   fakeUserCaller,
-  tokenSuperadmin,
 } from "./helpers/fixtures"
 import { createTestHarness, type TestHarness } from "./helpers/harness"
 
@@ -29,11 +30,14 @@ import { createTestHarness, type TestHarness } from "./helpers/harness"
 describe("invitations", () => {
   let h: TestHarness
   let inviter: { id: string }
+  /** A real IdP-level admin key, resolved through the production resolver. */
+  let root: Caller
 
   const CATALOG = ["invoices:read", "invoices:write"]
 
   beforeEach(async () => {
     h = createTestHarness()
+    root = (await bootstrapAdminKey(h.ctx)).caller
     await createApplication(h.ctx, { app: "acme", permissions: CATALOG })
     inviter = await createUser(h.ctx, { email: "inviter@acme.test" })
   })
@@ -136,7 +140,7 @@ describe("invitations", () => {
       .set({ expiresAt: new Date(Date.now() + 1000) })
       .where(eq(schema.applicationInvitation.id, pending.id))
 
-    const result = await resendInvitation(h.ctx, tokenSuperadmin(), {
+    const result = await resendInvitation(h.ctx, root, {
       app: "acme",
       invitationId: pending.id,
       origin: "https://idp.willy.im",
@@ -150,7 +154,7 @@ describe("invitations", () => {
   it("revokes a pending invitation so sign-in grants nothing", async () => {
     await invite()
     const [pending] = await listAppInvitations(h.ctx, "acme")
-    await revokeInvitation(h.ctx, tokenSuperadmin(), { app: "acme", invitationId: pending.id })
+    await revokeInvitation(h.ctx, root, { app: "acme", invitationId: pending.id })
 
     expect(await listAppInvitations(h.ctx, "acme")).toHaveLength(0)
 
@@ -248,8 +252,11 @@ describe("invitations", () => {
 
 describe("member management", () => {
   let h: TestHarness
+  /** A real IdP-level admin key, resolved through the production resolver. */
+  let root: Caller
   beforeEach(async () => {
     h = createTestHarness()
+    root = (await bootstrapAdminKey(h.ctx)).caller
     await createApplication(h.ctx, { app: "acme", permissions: ["invoices:read"] })
   })
   afterEach(() => h.close())
@@ -258,7 +265,7 @@ describe("member management", () => {
     const boss = await createUser(h.ctx, { email: "boss@acme.test" })
     await createMember(h.ctx, { app: "acme", userId: boss.id, role: "admin" })
 
-    const result = await updateAppMember(h.ctx, tokenSuperadmin(), {
+    const result = await updateAppMember(h.ctx, root, {
       app: "acme",
       userId: boss.id,
       role: "member",
@@ -274,7 +281,7 @@ describe("member management", () => {
     await createMember(h.ctx, { app: "acme", userId: boss.id, role: "admin" })
 
     expect(
-      await removeAppMember(h.ctx, tokenSuperadmin(), { app: "acme", userId: boss.id }),
+      await removeAppMember(h.ctx, root, { app: "acme", userId: boss.id }),
     ).toEqual({
       error: "Can't remove the last admin — promote someone else first.",
     })
@@ -287,7 +294,7 @@ describe("member management", () => {
     await createMember(h.ctx, { app: "acme", userId: deputy.id, role: "admin" })
 
     expect(
-      await updateAppMember(h.ctx, tokenSuperadmin(), {
+      await updateAppMember(h.ctx, root, {
         app: "acme",
         userId: deputy.id,
         role: "member",
@@ -324,25 +331,25 @@ describe("member management", () => {
     await createMember(h.ctx, { app: "acme", userId: boss.id, role: "admin" })
     await createMember(h.ctx, { app: "acme", userId: deputy.id, role: "member" })
 
-    await updateAppMember(h.ctx, tokenSuperadmin(), {
+    await updateAppMember(h.ctx, root, {
       app: "acme",
       userId: deputy.id,
       role: "member",
       permissions: ["member:read"],
     })
-    await removeAppMember(h.ctx, tokenSuperadmin(), { app: "acme", userId: deputy.id })
+    await removeAppMember(h.ctx, root, { app: "acme", userId: deputy.id })
 
     const entries = await listAuditForApp(h.ctx, "acme")
     expect(entries.map((e) => [e.tableName, e.operation, e.rowId])).toEqual([
       ["application_member", "delete", deputy.id],
       ["application_member", "update", deputy.id],
     ])
-    expect(entries[0].actor).toBe("superadmin-token")
+    expect(entries[0].actor).toBe(`adminkey:${root.keyId}`)
   })
 
   it("reports a missing member rather than silently succeeding", async () => {
     expect(
-      await removeAppMember(h.ctx, tokenSuperadmin(), { app: "acme", userId: "ghost" }),
+      await removeAppMember(h.ctx, root, { app: "acme", userId: "ghost" }),
     ).toEqual({
       error: "Member not found.",
     })

--- a/apps/idp/test/user-api-keys.test.ts
+++ b/apps/idp/test/user-api-keys.test.ts
@@ -7,7 +7,13 @@ import {
   validateUserApiKey,
 } from "../app/lib/user-api-keys.server"
 import { listAuditForApp } from "../app/lib/audit.server"
-import { createApplication, createUser, fakeUserCaller, tokenSuperadmin } from "./helpers/fixtures"
+import type { Caller } from "../app/lib/caller.server"
+import {
+  bootstrapAdminKey,
+  createApplication,
+  createUser,
+  fakeUserCaller,
+} from "./helpers/fixtures"
 import { createTestHarness, type TestHarness } from "./helpers/harness"
 
 /**
@@ -17,18 +23,21 @@ import { createTestHarness, type TestHarness } from "./helpers/harness"
 describe("end-user API keys", () => {
   let h: TestHarness
   let user: { id: string }
+  /** A real IdP-level admin key, resolved through the production resolver. */
+  let root: Caller
 
   const CATALOG = ["invoices:read", "invoices:write"]
 
   beforeEach(async () => {
     h = createTestHarness()
+    root = (await bootstrapAdminKey(h.ctx)).caller
     await createApplication(h.ctx, { app: "acme", permissions: CATALOG })
     user = await createUser(h.ctx, { email: "enduser@acme.test" })
   })
   afterEach(() => h.close())
 
   const mint = (overrides: Partial<Parameters<typeof createUserApiKey>[2]> = {}) =>
-    createUserApiKey(h.ctx, tokenSuperadmin(), {
+    createUserApiKey(h.ctx, root, {
       app: "acme",
       userId: user.id,
       name: "CLI token",
@@ -43,7 +52,7 @@ describe("end-user API keys", () => {
 
     expect(minted.token.startsWith("wak_")).toBe(true)
 
-    const [listed] = await listUserApiKeys(h.ctx, tokenSuperadmin(), { app: "acme" })
+    const [listed] = await listUserApiKeys(h.ctx, root, { app: "acme" })
     expect(listed.id).toBe(minted.id)
     expect(listed.scopes).toEqual(["invoices:read"])
     expect(listed.status).toBe("active")
@@ -65,7 +74,7 @@ describe("end-user API keys", () => {
     const minted = await mint({ scopes: ["invoices:read", "invoices:write"] })
     if (!("token" in minted)) throw new Error("mint failed")
 
-    const result = await validateUserApiKey(h.ctx, tokenSuperadmin(), {
+    const result = await validateUserApiKey(h.ctx, root, {
       app: "acme",
       token: minted.token,
     })
@@ -84,7 +93,7 @@ describe("end-user API keys", () => {
     if (!("token" in minted)) throw new Error("mint failed")
 
     expect(
-      await validateUserApiKey(h.ctx, tokenSuperadmin(), { app: "other", token: minted.token }),
+      await validateUserApiKey(h.ctx, root, { app: "other", token: minted.token }),
     ).toEqual({
       valid: false,
       reason: "not_found",
@@ -93,14 +102,14 @@ describe("end-user API keys", () => {
 
   it("reports not_found for a garbage token", async () => {
     expect(
-      await validateUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", token: "wak_nonsense" }),
+      await validateUserApiKey(h.ctx, root, { app: "acme", token: "wak_nonsense" }),
     ).toEqual({
       valid: false,
       reason: "not_found",
     })
     // A token that isn't even ours is rejected without a database round-trip.
     expect(
-      await validateUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", token: "bearer-ish" }),
+      await validateUserApiKey(h.ctx, root, { app: "acme", token: "bearer-ish" }),
     ).toEqual({
       valid: false,
       reason: "not_found",
@@ -111,9 +120,9 @@ describe("end-user API keys", () => {
     const minted = await mint()
     if (!("token" in minted)) throw new Error("mint failed")
 
-    await revokeUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", id: minted.id })
+    await revokeUserApiKey(h.ctx, root, { app: "acme", id: minted.id })
     expect(
-      await validateUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", token: minted.token }),
+      await validateUserApiKey(h.ctx, root, { app: "acme", token: minted.token }),
     ).toEqual({
       valid: false,
       reason: "revoked",
@@ -125,7 +134,7 @@ describe("end-user API keys", () => {
     if (!("token" in minted)) throw new Error("mint failed")
 
     expect(
-      await validateUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", token: minted.token }),
+      await validateUserApiKey(h.ctx, root, { app: "acme", token: minted.token }),
     ).toEqual({
       valid: false,
       reason: "expired",
@@ -137,14 +146,14 @@ describe("end-user API keys", () => {
     if (!("token" in minted)) throw new Error("mint failed")
 
     expect(
-      await revokeUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", id: minted.id }),
+      await revokeUserApiKey(h.ctx, root, { app: "acme", id: minted.id }),
     ).toEqual({ ok: true })
-    const [first] = await listUserApiKeys(h.ctx, tokenSuperadmin(), { app: "acme" })
+    const [first] = await listUserApiKeys(h.ctx, root, { app: "acme" })
 
     expect(
-      await revokeUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", id: minted.id }),
+      await revokeUserApiKey(h.ctx, root, { app: "acme", id: minted.id }),
     ).toEqual({ ok: true })
-    const [second] = await listUserApiKeys(h.ctx, tokenSuperadmin(), { app: "acme" })
+    const [second] = await listUserApiKeys(h.ctx, root, { app: "acme" })
 
     expect(second.status).toBe("revoked")
     expect(second.revokedAt).toEqual(first.revokedAt)
@@ -180,14 +189,14 @@ describe("end-user API keys", () => {
   it("audits the mint and the revocation against the app", async () => {
     const minted = await mint()
     if (!("token" in minted)) throw new Error("mint failed")
-    await revokeUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", id: minted.id })
+    await revokeUserApiKey(h.ctx, root, { app: "acme", id: minted.id })
 
     const entries = await listAuditForApp(h.ctx, "acme")
     expect(entries.map((e) => [e.tableName, e.operation, e.rowId])).toEqual([
       ["user_api_key", "revoke", minted.id],
       ["user_api_key", "create", minted.id],
     ])
-    expect(entries[1].actor).toBe("superadmin-token")
+    expect(entries[1].actor).toBe(`adminkey:${root.keyId}`)
   })
 
   it("will not let one app revoke another app's key", async () => {
@@ -195,12 +204,12 @@ describe("end-user API keys", () => {
     if (!("token" in minted)) throw new Error("mint failed")
 
     expect(
-      await revokeUserApiKey(h.ctx, tokenSuperadmin(), { app: "other", id: minted.id }),
+      await revokeUserApiKey(h.ctx, root, { app: "other", id: minted.id }),
     ).toEqual({
       error: "Key not found.",
     })
     expect(
-      await validateUserApiKey(h.ctx, tokenSuperadmin(), { app: "acme", token: minted.token }),
+      await validateUserApiKey(h.ctx, root, { app: "acme", token: minted.token }),
     ).toMatchObject({
       valid: true,
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -16115,7 +16115,7 @@
     },
     "packages/idp-client": {
       "name": "@willyim/idp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.1.11"

--- a/packages/idp-client/README.md
+++ b/packages/idp-client/README.md
@@ -358,9 +358,14 @@ const { token } = await api.request("post", "/api/v1/admin-keys", {
 //   Authorization: Bearer wim_…
 ```
 
-The IdP's static `ADMIN_API_TOKEN` still works and still grants superadmin, but
-it is break-glass only: one shared secret, no name, no expiry, and no way to
-revoke it short of a redeploy.
+There is no static superadmin secret: every bearer the IdP accepts is a key row
+it issued, so every superadmin action names a revocable credential.
+
+**Break-glass.** If every admin key is lost, recover by writing one bootstrap
+key straight into D1 — insert an `api_key` row with `application_id` NULL and
+`key_hash` set to the SHA-256 hex digest of a token you generate — then use it
+to mint a real key via `POST /api/v1/admin-keys` and revoke the bootstrap row
+through `DELETE /api/v1/admin-keys/{id}`.
 
 The OIDC endpoints are not in that document and never will be: they are
 standards-defined and discovered at runtime from `.well-known`.

--- a/packages/idp-client/openapi/idp-api.json
+++ b/packages/idp-client/openapi/idp-api.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "willy.im IdP — Management API",
     "version": "1.0.0",
-    "description": "Management API for the willy.im identity provider. Authenticate with `Authorization: Bearer <token>`. Two kinds of token: the superadmin `ADMIN_API_TOKEN` (every app) and per-app **scoped API keys** minted in the admin console (one app, a fixed permission set). The cross-app endpoints below require the superadmin token."
+    "description": "Management API for the willy.im identity provider. Authenticate with `Authorization: Bearer <token>`. Two kinds of bearer, both `wim_` keys: IdP-level **admin keys** (every permission on every app, minted at `/api/v1/admin-keys`) and per-app **scoped keys** minted in the admin console (one app, a fixed permission set). The cross-app endpoints below require an admin key."
   },
   "servers": [
     {
@@ -15,7 +15,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Superadmin ADMIN_API_TOKEN or a scoped API key (wim_…)."
+        "description": "An IdP-level admin key or a per-app scoped key (wim_…)."
       }
     }
   },
@@ -23,7 +23,7 @@
     "/api/v1/applications": {
       "get": {
         "summary": "List registered applications",
-        "description": "Requires the superadmin token.",
+        "description": "Requires an admin key.",
         "security": [
           {
             "bearerAuth": []
@@ -121,7 +121,7 @@
       },
       "post": {
         "summary": "Register an application (client secret returned once)",
-        "description": "Requires the superadmin token. Creating an application is an IdP-level act — there is no app to scope a permission to yet.",
+        "description": "Requires an admin key. Creating an application is an IdP-level act — there is no app to scope a permission to yet.",
         "security": [
           {
             "bearerAuth": []
@@ -222,7 +222,7 @@
     "/api/v1/applications/{clientId}": {
       "get": {
         "summary": "Get one application",
-        "description": "Requires `app:read` on the path app (or the superadmin token).",
+        "description": "Requires `app:read` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -325,7 +325,7 @@
       },
       "patch": {
         "summary": "Update an application",
-        "description": "Requires `app:update` on the path app (or the superadmin token).",
+        "description": "Requires `app:update` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -465,7 +465,7 @@
       },
       "delete": {
         "summary": "Deregister an application",
-        "description": "Requires `app:delete` on the path app (or the superadmin token).",
+        "description": "Requires `app:delete` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -525,7 +525,7 @@
     "/api/v1/applications/{clientId}/rotate-secret": {
       "post": {
         "summary": "Rotate the client secret (returned once; the old one stops working)",
-        "description": "Requires `app:update` on the path app (or the superadmin token).",
+        "description": "Requires `app:update` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -585,7 +585,7 @@
     "/api/v1/apps/{app}/permissions": {
       "put": {
         "summary": "Replace the app's product-permission catalog",
-        "description": "Requires `app:update` on the path app (or the superadmin token).",
+        "description": "Requires `app:update` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -673,7 +673,7 @@
     "/api/v1/apps/{app}/keys": {
       "get": {
         "summary": "List scoped management API keys (never the hashes)",
-        "description": "Requires `apikey:read` on the path app (or the superadmin token).",
+        "description": "Requires `apikey:read` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -796,7 +796,7 @@
       },
       "post": {
         "summary": "Mint a scoped management API key (plaintext returned once)",
-        "description": "Requires `apikey:create` on the path app (or the superadmin token). The requested permissions must be a subset of the caller's own, otherwise 403 `permissions_exceed_caller` — without that rule any key holding `apikey:create` could mint itself a more powerful successor.",
+        "description": "Requires `apikey:create` on the path app (or an admin key). The requested permissions must be a subset of the caller's own, otherwise 403 `permissions_exceed_caller` — without that rule any key holding `apikey:create` could mint itself a more powerful successor.",
         "security": [
           {
             "bearerAuth": []
@@ -899,7 +899,7 @@
     "/api/v1/apps/{app}/keys/{id}": {
       "delete": {
         "summary": "Revoke a scoped management API key (idempotent)",
-        "description": "Requires `apikey:revoke` on the path app (or the superadmin token).",
+        "description": "Requires `apikey:revoke` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -967,7 +967,7 @@
     "/api/v1/admin-keys": {
       "get": {
         "summary": "List IdP-level admin keys (never the hashes)",
-        "description": "Requires the superadmin token or an admin key. Admin keys are `api_key` rows with no application scope, so they hold every permission on every app.",
+        "description": "Requires an admin key. Admin keys are `api_key` rows with no application scope, so they hold every permission on every app.",
         "security": [
           {
             "bearerAuth": []
@@ -1068,7 +1068,7 @@
       },
       "post": {
         "summary": "Mint an IdP-level admin key (plaintext returned once)",
-        "description": "Requires the superadmin token or an admin key. Mint one per agent: unlike the static ADMIN_API_TOKEN, an admin key has a name, an optional expiry, a revoke switch, and its own `adminkey:<id>` identity in the audit log.",
+        "description": "Requires an admin key. Mint one per agent: an admin key has a name, an optional expiry, a revoke switch, and its own `adminkey:<id>` identity in the audit log, so every superadmin action is attributable.",
         "security": [
           {
             "bearerAuth": []
@@ -1206,7 +1206,7 @@
     "/api/v1/users": {
       "get": {
         "summary": "List users",
-        "description": "Requires the superadmin token.",
+        "description": "Requires an admin key.",
         "security": [
           {
             "bearerAuth": []
@@ -1277,7 +1277,7 @@
     "/api/v1/workspaces": {
       "get": {
         "summary": "List workspaces",
-        "description": "Requires the superadmin token.",
+        "description": "Requires an admin key.",
         "security": [
           {
             "bearerAuth": []
@@ -1348,7 +1348,7 @@
     "/api/v1/apps/{app}/members": {
       "get": {
         "summary": "List app members",
-        "description": "Requires `member:read` on the path app (or the superadmin token).",
+        "description": "Requires `member:read` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -1438,7 +1438,7 @@
       },
       "post": {
         "summary": "Add or invite a member",
-        "description": "Requires `member:invite` on the path app (or the superadmin token).",
+        "description": "Requires `member:invite` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -1537,7 +1537,7 @@
     "/api/v1/apps/{app}/members/{userId}": {
       "patch": {
         "summary": "Update a member's role + permissions",
-        "description": "Requires `member:manage` on the path app (or the superadmin token).",
+        "description": "Requires `member:manage` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -1633,7 +1633,7 @@
       },
       "delete": {
         "summary": "Remove a member",
-        "description": "Requires `member:manage` on the path app (or the superadmin token).",
+        "description": "Requires `member:manage` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -1698,7 +1698,7 @@
     "/api/v1/apps/{app}/workspaces": {
       "get": {
         "summary": "List app workspaces",
-        "description": "Requires `workspace:read` on the path app (or the superadmin token).",
+        "description": "Requires `workspace:read` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -1781,7 +1781,7 @@
       },
       "post": {
         "summary": "Create a workspace",
-        "description": "Requires `workspace:create` on the path app (or the superadmin token).",
+        "description": "Requires `workspace:create` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -1874,7 +1874,7 @@
     "/api/v1/apps/{app}/user-keys": {
       "get": {
         "summary": "List end-user API keys",
-        "description": "Requires `userkey:read` on the path app (or the superadmin token).",
+        "description": "Requires `userkey:read` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -2018,7 +2018,7 @@
       },
       "post": {
         "summary": "Mint an end-user API key (plaintext returned once)",
-        "description": "Requires `userkey:create` on the path app (or the superadmin token).",
+        "description": "Requires `userkey:create` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -2128,7 +2128,7 @@
     "/api/v1/apps/{app}/user-keys/validate": {
       "post": {
         "summary": "Validate a presented end-user key (200 + valid discriminator)",
-        "description": "Requires `userkey:validate` on the path app (or the superadmin token).",
+        "description": "Requires `userkey:validate` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -2264,7 +2264,7 @@
     "/api/v1/apps/{app}/user-keys/{id}": {
       "delete": {
         "summary": "Revoke an end-user API key (idempotent)",
-        "description": "Requires `userkey:revoke` on the path app (or the superadmin token).",
+        "description": "Requires `userkey:revoke` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []
@@ -2329,7 +2329,7 @@
     "/api/v1/apps/{app}/audit": {
       "get": {
         "summary": "List recent audit entries",
-        "description": "Requires `audit:read` on the path app (or the superadmin token).",
+        "description": "Requires `audit:read` on the path app (or an admin key).",
         "security": [
           {
             "bearerAuth": []

--- a/packages/idp-client/package.json
+++ b/packages/idp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/idp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Login for apps that don't own identity \u2014 OIDC client, server sessions, and react-router guards against the willy.im IdP",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/idp-client/src/api.ts
+++ b/packages/idp-client/src/api.ts
@@ -54,7 +54,7 @@ export type RequestOptions<P extends string, O> = PathParams<P> &
 export type ManagementApiOptions = {
   /** IdP origin — the API lives at the root, not under the `/auth` basepath. */
   baseUrl: string
-  /** Superadmin `ADMIN_API_TOKEN` or a scoped `wim_…` key. */
+  /** An IdP-level admin key or a per-app scoped `wim_…` key. */
   token: string
   fetch?: typeof fetch
 }

--- a/packages/idp-client/src/schemas/openapi.ts
+++ b/packages/idp-client/src/schemas/openapi.ts
@@ -21,7 +21,7 @@ const json = (schema: z.ZodType) => z.toJSONSchema(schema)
 const jsonInput = (schema: z.ZodType) => z.toJSONSchema(schema, { io: "input" })
 
 const DESCRIPTION =
-  "Management API for the willy.im identity provider. Authenticate with `Authorization: Bearer <token>`. Two kinds of token: the superadmin `ADMIN_API_TOKEN` (every app) and per-app **scoped API keys** minted in the admin console (one app, a fixed permission set). The cross-app endpoints below require the superadmin token."
+  "Management API for the willy.im identity provider. Authenticate with `Authorization: Bearer <token>`. Two kinds of bearer, both `wim_` keys: IdP-level **admin keys** (every permission on every app, minted at `/api/v1/admin-keys`) and per-app **scoped keys** minted in the admin console (one app, a fixed permission set). The cross-app endpoints below require an admin key."
 
 function pathParamNames(path: string): string[] {
   return [...path.matchAll(/\{([^}]+)\}/g)].map((match) => match[1])
@@ -54,8 +54,8 @@ function operationObject(method: string, path: string, def: OperationDef) {
     description:
       def.description ??
       (scoped
-        ? `Requires \`${def.permission}\` on the path app (or the superadmin token).`
-        : "Requires the superadmin token."),
+        ? `Requires \`${def.permission}\` on the path app (or an admin key).`
+        : "Requires an admin key."),
     security: [{ bearerAuth: [] }],
     ...(parameters.length ? { parameters } : {}),
     ...(def.input
@@ -112,7 +112,7 @@ export function buildOpenApiDocument(input: { baseUrl: string }) {
         bearerAuth: {
           type: "http",
           scheme: "bearer",
-          description: "Superadmin ADMIN_API_TOKEN or a scoped API key (wim_…).",
+          description: "An IdP-level admin key or a per-app scoped key (wim_…).",
         },
       },
     },

--- a/packages/idp-client/src/schemas/operations.ts
+++ b/packages/idp-client/src/schemas/operations.ts
@@ -77,7 +77,7 @@ export const operations = {
   "post /api/v1/applications": {
     summary: "Register an application (client secret returned once)",
     description:
-      "Requires the superadmin token. Creating an application is an IdP-level act — there is no app to scope a permission to yet.",
+      "Requires an admin key. Creating an application is an IdP-level act — there is no app to scope a permission to yet.",
     input: CreateApplicationInput,
     successCode: "201",
     success: ApplicationCreatedSchema,
@@ -134,7 +134,7 @@ export const operations = {
   "post /api/v1/apps/{app}/keys": {
     summary: "Mint a scoped management API key (plaintext returned once)",
     description:
-      "Requires `apikey:create` on the path app (or the superadmin token). The requested permissions must be a subset of the caller's own, otherwise 403 `permissions_exceed_caller` — without that rule any key holding `apikey:create` could mint itself a more powerful successor.",
+      "Requires `apikey:create` on the path app (or an admin key). The requested permissions must be a subset of the caller's own, otherwise 403 `permissions_exceed_caller` — without that rule any key holding `apikey:create` could mint itself a more powerful successor.",
     permission: "apikey:create",
     params: APP_PARAM,
     input: CreateApiKeyInput,
@@ -152,14 +152,14 @@ export const operations = {
   "get /api/v1/admin-keys": {
     summary: "List IdP-level admin keys (never the hashes)",
     description:
-      "Requires the superadmin token or an admin key. Admin keys are `api_key` rows with no application scope, so they hold every permission on every app.",
+      "Requires an admin key. Admin keys are `api_key` rows with no application scope, so they hold every permission on every app.",
     successCode: "200",
     success: AdminKeyListSchema,
   },
   "post /api/v1/admin-keys": {
     summary: "Mint an IdP-level admin key (plaintext returned once)",
     description:
-      "Requires the superadmin token or an admin key. Mint one per agent: unlike the static ADMIN_API_TOKEN, an admin key has a name, an optional expiry, a revoke switch, and its own `adminkey:<id>` identity in the audit log.",
+      "Requires an admin key. Mint one per agent: an admin key has a name, an optional expiry, a revoke switch, and its own `adminkey:<id>` identity in the audit log, so every superadmin action is attributable.",
     input: CreateAdminKeyInput,
     successCode: "201",
     success: AdminKeyCreatedSchema,


### PR DESCRIPTION
## What

Removes the env-configured superadmin credential. Named admin keys (`/api/v1/admin-keys`, PR #51) replaced it, and the Worker secret has already been deleted from prod — this makes the code match: `resolveCaller` has exactly one bearer path (a `wim_` key row we issued), and setting `ADMIN_API_TOKEN` again would arm nothing.

- `superadminCaller` takes a discriminated origin (session user | admin key); the `superadmin-token` audit label can no longer be constructed
- `ADMIN_API_TOKEN` removed from the env schema
- docs, OpenAPI description and security scheme rewritten to the two-bearer story; `@willyim/idp` 0.3.1 (doc-only)
- README break-glass note now gives the recovery recipe (one bootstrap `api_key` row in D1 → mint through the API → revoke the bootstrap) instead of pointing at a secret

## Verification

- `grep -rn "ADMIN_API_TOKEN\|superadmin-token" apps packages` → empty (regenerated `openapi/idp-api.json` included)
- `apps/idp`: 184 tests (net zero: one static-token test out, one "no env backdoor" test in), typecheck clean
- `packages/idp-client`: 105 tests, typecheck + build clean
- external usage: none in this repo, local checkouts, or GitHub code search across the account

## Deploy

No migration. The secret is already gone from the worker, so prod behaviour is unchanged by this deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
