### PR TITLE
idp: OAuth for MCP — per-app resources, DCR, resource-scoped tokens + resource-server helper

### DIFF
--- a/apps/idp/app/lib/admin.server.ts
+++ b/apps/idp/app/lib/admin.server.ts
@@ -24,6 +24,8 @@ export type ApplicationSummary = {
   app: string | null
   allowSignup: boolean
   permissions: string[]
+  /** Protected resource URIs (e.g. the app's MCP server) — valid `resource` audiences. */
+  resources: string[]
   redirectUris: string[]
   disabled: boolean
   createdAt: Date
@@ -50,6 +52,7 @@ export async function listApplications(ctx: BaseServiceContext): Promise<Applica
       app: meta.app,
       allowSignup: meta.allow_signup,
       permissions: meta.permissions,
+      resources: meta.resources,
       redirectUris: coerceUriList(r.redirectUris),
       disabled: !!r.disabled,
       createdAt: r.createdAt ?? new Date(0),
@@ -105,7 +108,7 @@ export async function updateApplicationMetadata(
   await assertCan(caller, app, "app:update")
   await ctx.db
     .update(schema.oauthClient)
-    .set({ metadata: { app: app || null, allow_signup: config.allow_signup, permissions: config.permissions } })
+    .set({ metadata: { app: app || null, allow_signup: config.allow_signup, permissions: config.permissions, resources: config.resources } })
     .where(eq(schema.oauthClient.clientId, clientId))
   await recordAudit(ctx, {
     actor: caller.actor,
@@ -138,7 +141,7 @@ export async function updateApplicationPermissions(
   const next = [...new Set(permissions.map((p) => p.trim()).filter(Boolean))]
   await ctx.db
     .update(schema.oauthClient)
-    .set({ metadata: { app: meta.app, allow_signup: meta.allow_signup, permissions: next } })
+    .set({ metadata: { app: meta.app, allow_signup: meta.allow_signup, permissions: next, resources: meta.resources } })
     .where(eq(schema.oauthClient.clientId, clientId))
   await recordAudit(ctx, {
     actor: caller.actor,
@@ -374,8 +377,12 @@ export async function updateApplication(
   ctx: BaseServiceContext,
   caller: Caller,
   clientId: string,
-  patch: { name?: string; redirectUris?: string[]; allowSignup?: boolean },
-): Promise<ApplicationSummary | { error: "invalid_redirect_uri"; detail: string } | null> {
+  patch: { name?: string; redirectUris?: string[]; allowSignup?: boolean; resources?: string[] },
+): Promise<
+  | ApplicationSummary
+  | { error: "invalid_redirect_uri" | "invalid_resource"; detail: string }
+  | null
+> {
   const current = await getApplication(ctx, clientId)
   if (!current) return null
   await assertCan(caller, current.app ?? "", "app:update")
@@ -384,18 +391,33 @@ export async function updateApplication(
     const invalid = firstInvalidRedirectUri(patch.redirectUris)
     if (invalid) return { error: "invalid_redirect_uri", detail: invalid }
   }
+  // A resource is an audience a token will be minted FOR, so it has to be an
+  // absolute https URI with no fragment (RFC 8707 §2) — anything looser and a
+  // token could be minted for a string no resource server will ever match.
+  const resources = patch.resources?.map((r) => r.trim()).filter(Boolean)
+  if (resources) {
+    for (const r of resources) {
+      let parsed: URL | null = null
+      try { parsed = new URL(r) } catch { /* handled below */ }
+      if (!parsed || parsed.protocol !== "https:" || parsed.hash) {
+        return { error: "invalid_resource", detail: r }
+      }
+    }
+  }
+  const metadataChanged = patch.allowSignup !== undefined || resources !== undefined
 
   await ctx.db
     .update(schema.oauthClient)
     .set({
       ...(patch.name !== undefined ? { name: patch.name } : {}),
       ...(patch.redirectUris !== undefined ? { redirectUris: patch.redirectUris } : {}),
-      ...(patch.allowSignup !== undefined
+      ...(metadataChanged
         ? {
             metadata: {
               app: current.app,
-              allow_signup: patch.allowSignup,
+              allow_signup: patch.allowSignup ?? current.allowSignup,
               permissions: current.permissions,
+              resources: resources ?? current.resources,
             },
           }
         : {}),

--- a/apps/idp/app/lib/auth.server.ts
+++ b/apps/idp/app/lib/auth.server.ts
@@ -11,7 +11,7 @@ import { oauthProvider } from "@better-auth/oauth-provider"
 import { Resend } from "resend"
 
 import * as schema from "../db/schema"
-import { customClaimsFor } from "./claims.server"
+import { accessTokenClaimsFor, customClaimsFor } from "./claims.server"
 import { hashClientSecret } from "./client-secret.server"
 import { claimInvitationsForUser } from "./members.server"
 import type { BaseServiceContext } from "./services"
@@ -48,7 +48,19 @@ function renderOtpEmail(baseUrl: string, email: string, otp: string) {
  * store are shared, so an account works on every domain; sessions and passkeys
  * are per-domain by design (no cross-domain SSO).
  */
-export function createAuthService(context: BaseServiceContext, requestUrl?: string) {
+export function createAuthService(
+  context: BaseServiceContext,
+  requestUrl?: string,
+  options: {
+    /**
+     * Every resource URI any application declares (claims.server allResources),
+     * loaded by the worker before this is built. The token endpoint refuses a
+     * `resource` outside this list, so an access token can only ever be minted
+     * for an audience some registered app actually is.
+     */
+    audiences?: string[]
+  } = {},
+) {
   const env = context.getAppEnv()
   const isProd = env.APP_ENV === "production"
   const canonical = new URL(env.BETTER_AUTH_URL)
@@ -212,6 +224,20 @@ export function createAuthService(context: BaseServiceContext, requestUrl?: stri
         // Each OAuth client is tagged with metadata.app (its application key).
         // We surface only that application's workspaces + roles as a claim.
         customIdTokenClaims: ({ user, metadata }) => customClaimsFor(context.db, user.id, metadata),
+        // ── MCP / resource servers ──────────────────────────────────────────
+        // An MCP client (Claude, Claude Code, …) discovers this server from the
+        // resource's protected-resource metadata, registers itself (RFC 7591,
+        // anonymously — it is a public client with PKCE), and asks for a token
+        // with `resource=<the MCP url>` (RFC 8707). The plugin then mints a JWT
+        // access token with that audience, and the claims below stamp the
+        // user's permissions FOR THE APP THAT OWNS THE RESOURCE on it — so the
+        // resource server verifies one signature and reads one claim.
+        allowDynamicClientRegistration: true,
+        allowUnauthenticatedClientRegistration: true,
+        clientRegistrationDefaultScopes: ["openid", "profile", "email", "offline_access"],
+        validAudiences: [url.origin + "/auth", ...(options.audiences ?? [])],
+        customAccessTokenClaims: ({ user, resource, metadata }) =>
+          user ? accessTokenClaimsFor(context.db, user.id, resource, metadata) : {},
         // Same claims on /userinfo, so apps that refresh server-side (or skip
         // id_token parsing) still see workspaces/permissions and — crucially —
         // a LIVE `act` claim while an admin is impersonating the user, letting

--- a/apps/idp/app/lib/claims.server.ts
+++ b/apps/idp/app/lib/claims.server.ts
@@ -101,6 +101,67 @@ export async function workspaceClaimsFor(
     .where(and(eq(schema.member.userId, userId), eq(schema.organization.applicationId, app)))
 }
 
+/** The application key a token is for — carried in the access token so a resource server can say which app's grants it holds. */
+export const APP_CLAIM = "https://willy.im/app"
+
+/**
+ * Which application owns `resource` — the app whose metadata lists that URI.
+ * Null when nobody does, which the token endpoint has already refused by then
+ * (validAudiences), so this is a lookup, not a gate. Exact match, because an
+ * audience is compared exactly on the other side.
+ */
+export async function appForResource(
+  db: BaseServiceContext["db"],
+  resource: string,
+): Promise<{ app: string; catalog: string[] } | null> {
+  const rows = await db.select({ metadata: schema.oauthClient.metadata }).from(schema.oauthClient)
+  for (const row of rows) {
+    const meta = parseAppMetadata(row.metadata)
+    if (meta.app && meta.resources.includes(resource)) {
+      return { app: meta.app, catalog: meta.permissions }
+    }
+  }
+  return null
+}
+
+/** Every resource URI any application declares — the token endpoint's valid audiences. */
+export async function allResources(db: BaseServiceContext["db"]): Promise<string[]> {
+  const rows = await db.select({ metadata: schema.oauthClient.metadata }).from(schema.oauthClient)
+  return [...new Set(rows.flatMap((row) => parseAppMetadata(row.metadata).resources))]
+}
+
+/**
+ * The claims on an ACCESS token. An access token is what a resource server
+ * (an MCP server, an API) reads, so unlike the id_token it carries the
+ * permissions for the app that owns the requested `resource`, not for the
+ * OAuth client that asked. That distinction is the whole point: Claude is one
+ * client registered once, and the same access token flow hands it bender's
+ * grants when it asks for bender's resource and another app's when it asks
+ * for theirs. Without a resource we fall back to the client's own app, which
+ * is the pre-MCP behaviour for first-party clients.
+ */
+export async function accessTokenClaimsFor(
+  db: BaseServiceContext["db"],
+  userId: string,
+  resource: string | string[] | undefined,
+  metadata: unknown,
+): Promise<Record<string, unknown>> {
+  const requested = Array.isArray(resource) ? resource[0] : resource
+  const owner = requested ? await appForResource(db, requested) : null
+  const meta = parseAppMetadata(metadata)
+  const app = owner?.app ?? meta.app ?? undefined
+  const catalog = owner?.catalog ?? meta.permissions
+  const [permissions, act] = await Promise.all([
+    productPermissionsFor(db, userId, app, catalog),
+    actClaimFor(db, userId),
+  ])
+  return {
+    ...(app ? { [APP_CLAIM]: app } : {}),
+    ...(permissions.length ? { [PERMISSIONS_CLAIM]: permissions } : {}),
+    ...(act ? { act } : {}),
+  }
+}
+
 /**
  * The custom claim set we attach for one app: workspaces + product permissions
  * + the `act` impersonation marker. Shared by the id_token and userinfo hooks

--- a/apps/idp/app/lib/metadata.ts
+++ b/apps/idp/app/lib/metadata.ts
@@ -14,6 +14,14 @@ export const appConfigSchema = z.object({
   allow_signup: z.boolean().default(false),
   // The app's declared product-permission catalog (unique, non-empty strings).
   permissions: z.array(z.string().min(1)).default([]).transform(dedupe),
+  // The app's protected RESOURCES, as absolute URIs — e.g. its MCP server,
+  // `https://bender.romo.fyi/mcp`. An OAuth client (say, Claude) that asks for
+  // a token with `resource=<one of these>` (RFC 8707) gets a JWT whose `aud`
+  // is that URI and whose permissions claim is the user's grants for THIS app
+  // (claims.server.ts). That is what lets any app expose itself over MCP by
+  // registering here and nothing else: the resource server just verifies the
+  // JWT against our JWKS and reads the claim.
+  resources: z.array(z.string().url()).default([]).transform(dedupe),
 })
 export type AppConfig = z.infer<typeof appConfigSchema>
 
@@ -43,6 +51,6 @@ export function parseAppMetadata(raw: unknown): AppMetadata {
   const obj = (unwrapped && typeof unwrapped === "object" ? (unwrapped as Record<string, unknown>) : {}) ?? {}
   const app = typeof obj.app === "string" ? obj.app : null
   const parsed = appConfigSchema.safeParse(obj)
-  const config = parsed.success ? parsed.data : { allow_signup: false, permissions: [] }
+  const config = parsed.success ? parsed.data : { allow_signup: false, permissions: [], resources: [] }
   return { app, ...config }
 }

--- a/apps/idp/test/access-token-claims.test.ts
+++ b/apps/idp/test/access-token-claims.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { getApplication, updateApplication } from "../app/lib/admin.server"
+import type { Caller } from "../app/lib/caller.server"
+import {
+  APP_CLAIM,
+  PERMISSIONS_CLAIM,
+  accessTokenClaimsFor,
+  allResources,
+  appForResource,
+} from "../app/lib/claims.server"
+import { bootstrapAdminKey, createApplication, createMember, createUser } from "./helpers/fixtures"
+import { createTestHarness, type TestHarness } from "./helpers/harness"
+
+/**
+ * Access tokens for resource servers. The claim on the token is the user's
+ * grants for the app that OWNS the requested resource — not for the OAuth
+ * client that asked — which is what lets one dynamically-registered client
+ * (Claude) receive different grants for different apps' MCP servers.
+ */
+describe("access-token claims by resource", () => {
+  let h: TestHarness
+  let root: Caller
+  let bender: { clientId: string }
+  let willy: { id: string }
+  let gf: { id: string }
+
+  const BENDER_MCP = "https://bender.romo.fyi/mcp"
+  const CATALOG = ["chat:respond", "kirby:chats:read", "tool:publish_artifact"]
+
+  beforeEach(async () => {
+    h = createTestHarness()
+    root = (await bootstrapAdminKey(h.ctx)).caller
+    bender = await createApplication(h.ctx, { app: "bender", permissions: CATALOG })
+    await createApplication(h.ctx, { app: "other", permissions: ["x:read"] })
+    willy = await createUser(h.ctx, { email: "hey@willy.im" })
+    gf = await createUser(h.ctx, { email: "gf@example.com" })
+    await createMember(h.ctx, { app: "bender", userId: willy.id, role: "admin" })
+    await createMember(h.ctx, {
+      app: "bender",
+      userId: gf.id,
+      role: "member",
+      productPermissions: ["chat:respond", "tool:publish_artifact"],
+    })
+    await updateApplication(h.ctx, root, bender.clientId, { resources: [BENDER_MCP] })
+  })
+  afterEach(() => h.close())
+
+  describe("resources on an application", () => {
+    it("round-trip through the PATCH service and survive other metadata edits", async () => {
+      expect((await getApplication(h.ctx, bender.clientId))!.resources).toEqual([BENDER_MCP])
+      await updateApplication(h.ctx, root, bender.clientId, { allowSignup: true })
+      expect((await getApplication(h.ctx, bender.clientId))!.resources).toEqual([BENDER_MCP])
+    })
+
+    it("must be absolute https with no fragment — an audience is matched exactly", async () => {
+      for (const bad of ["http://bender.romo.fyi/mcp", "bender.romo.fyi/mcp", "https://bender.romo.fyi/mcp#x"]) {
+        const res = await updateApplication(h.ctx, root, bender.clientId, { resources: [bad] })
+        expect(res).toEqual({ error: "invalid_resource", detail: bad })
+      }
+    })
+
+    it("are the token endpoint's valid audiences", async () => {
+      expect(await allResources(h.ctx.db)).toEqual([BENDER_MCP])
+      expect(await appForResource(h.ctx.db, BENDER_MCP)).toEqual({ app: "bender", catalog: CATALOG })
+      expect(await appForResource(h.ctx.db, "https://nobody.example/mcp")).toBeNull()
+    })
+  })
+
+  describe("the claims", () => {
+    // A dynamically-registered client carries no `app` — exactly Claude's case.
+    const anonymousClient = {}
+
+    it("an admin asking for bender's resource gets bender's whole catalog", async () => {
+      const claims = await accessTokenClaimsFor(h.ctx.db, willy.id, BENDER_MCP, anonymousClient)
+      expect(claims[APP_CLAIM]).toBe("bender")
+      expect(claims[PERMISSIONS_CLAIM]).toEqual(CATALOG)
+    })
+
+    it("a member gets exactly their grants for that app", async () => {
+      const claims = await accessTokenClaimsFor(h.ctx.db, gf.id, BENDER_MCP, anonymousClient)
+      expect(claims[PERMISSIONS_CLAIM]).toEqual(["chat:respond", "tool:publish_artifact"])
+    })
+
+    it("a user with no membership in the owning app gets no permissions claim at all", async () => {
+      const stranger = await createUser(h.ctx, { email: "s@example.com" })
+      const claims = await accessTokenClaimsFor(h.ctx.db, stranger.id, BENDER_MCP, anonymousClient)
+      expect(claims[APP_CLAIM]).toBe("bender")
+      expect(claims[PERMISSIONS_CLAIM]).toBeUndefined()
+    })
+
+    it("the resource wins over the client's own app — one client, many resource servers", async () => {
+      // A first-party client tagged `other` asking for bender's resource is
+      // judged against bender, not against `other`.
+      const otherClient = { app: "other", permissions: ["x:read"] }
+      const claims = await accessTokenClaimsFor(h.ctx.db, willy.id, BENDER_MCP, otherClient)
+      expect(claims[APP_CLAIM]).toBe("bender")
+    })
+
+    it("no resource falls back to the client's app — the pre-MCP behaviour", async () => {
+      const benderClient = { app: "bender", permissions: CATALOG }
+      const claims = await accessTokenClaimsFor(h.ctx.db, gf.id, undefined, benderClient)
+      expect(claims[APP_CLAIM]).toBe("bender")
+      expect(claims[PERMISSIONS_CLAIM]).toEqual(["chat:respond", "tool:publish_artifact"])
+    })
+
+    it("an array of resources uses the first", async () => {
+      const claims = await accessTokenClaimsFor(h.ctx.db, willy.id, [BENDER_MCP], anonymousClient)
+      expect(claims[APP_CLAIM]).toBe("bender")
+    })
+  })
+})

--- a/apps/idp/workers/app.ts
+++ b/apps/idp/workers/app.ts
@@ -3,6 +3,26 @@ import { createRequestHandler } from "react-router"
 import type { DrizzleClient } from "../app/db/drizzle"
 import { getAppEnv } from "../app/lib/env"
 import { createAuthService, type AuthService } from "../app/lib/auth.server"
+import { allResources } from "../app/lib/claims.server"
+import type { BaseServiceContext } from "../app/lib/services"
+
+const AUDIENCE_TTL_MS = 60_000
+let audienceCache: { at: number; value: string[] } | null = null
+
+/** Resource URIs from every application, memoised per isolate for a minute. */
+async function cachedAudiences(ctx: Pick<BaseServiceContext, "db">) {
+  const now = Date.now()
+  if (audienceCache && now - audienceCache.at < AUDIENCE_TTL_MS) return audienceCache.value
+  try {
+    const value = await allResources(ctx.db)
+    audienceCache = { at: now, value }
+    return value
+  } catch {
+    // A failed load must not take the whole IdP down with it; the previous
+    // list (or none) stands until the next request.
+    return audienceCache?.value ?? []
+  }
+}
 import { createBaseContext, type ILogger } from "../app/lib/services"
 
 declare module "react-router" {
@@ -32,6 +52,10 @@ export default {
     const requestId = crypto.randomUUID().slice(0, 8)
 
     const baseCtx = createBaseContext(env.db, { requestId })
+    // The token endpoint's valid audiences — every resource URI a registered
+    // application declares. Cached across requests in this isolate; a newly
+    // registered resource is usable within AUDIENCE_TTL_MS.
+    const audiences = await cachedAudiences(baseCtx)
     baseCtx.logger.debug("request.start", {
       method: request.method,
       path: url.pathname,
@@ -46,7 +70,7 @@ export default {
         services: {
           // Host-aware: a request on a vanity IdP domain (IDP_EXTRA_DOMAINS)
           // gets that host as issuer/cookies/passkey RP.
-          auth: createAuthService(baseCtx, request.url),
+          auth: createAuthService(baseCtx, request.url, { audiences }),
         },
       })
       baseCtx.logger.debug("request.end", {

--- a/packages/idp-client/package.json
+++ b/packages/idp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willyim/idp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Login for apps that don't own identity \u2014 OIDC client, server sessions, and react-router guards against the willy.im IdP",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/idp-client/src/index.ts
+++ b/packages/idp-client/src/index.ts
@@ -85,6 +85,14 @@ export {
   type IdentityResolution,
 } from "./identities.js"
 
+export {
+  createResourceServer,
+  type ResourceServer,
+  type ResourceServerOptions,
+  type VerifiedAccessToken,
+  type AuthResult,
+} from "./resource-server.js"
+
 export { parseDuration, type Duration } from "./duration.js"
 export {
   clearCookie,

--- a/packages/idp-client/src/resource-server.ts
+++ b/packages/idp-client/src/resource-server.ts
@@ -14,21 +14,20 @@
  *      (RFC 7591), runs authorization code + PKCE with `resource=` (RFC 8707),
  *      and comes back with a JWT access token whose `aud` is this resource.
  *   4. The resource server verifies that JWT against the IdP's JWKS and reads
- *      the permissions claim                                → `verify()`
+ *      the permissions claim                                → `authenticate()`
  *
- * Step 4 is the only one with any code in it, and it is deliberately small:
- * signature (EdDSA, ES256 or RS256 via WebCrypto — no jose, no deps), issuer,
- * audience, time. The permissions on the token were computed by the IdP for
- * the app that owns this resource (the same way a browser session's are), so
- * the app does not look anything up — it reads a claim and matches it with
+ * Step 4 is the only one with any real code, and it is deliberately small:
+ * signature (EdDSA/Ed25519, ES256 or RS256 via WebCrypto — no jose, no deps),
+ * issuer, audience, time. The permissions on the token were computed by the
+ * IdP for the app that owns this resource (the same way a browser session's
+ * are), so the app looks nothing up — it reads a claim and matches it with
  * `grants()` like everywhere else.
  *
- * The JWKS is cached and refetched once on an unknown `kid`, which is how a
- * key rotation at the IdP is picked up without a restart.
+ * The JWKS is cached and refetched once on an unknown `kid`, which is how a key
+ * rotation at the IdP is picked up without a restart.
  */
 
 import { grants } from "./claims.js"
-import { IdpError } from "./errors.js"
 
 export const PERMISSIONS_CLAIM = "https://willy.im/permissions"
 export const APP_CLAIM = "https://willy.im/app"
@@ -59,4 +58,226 @@ export type ResourceServerOptions = {
 export type VerifiedAccessToken = {
   /** The IdP user id — the same `sub` a session or a wak_ key resolves to. */
   sub: string
-  /** The app the permissions are for (the owner of `resource`),
+  /** The app the permissions are for (the owner of `resource`), when present. */
+  app: string | null
+  /** The user's product permissions for that app. Match with `has()`/`grants()`. */
+  permissions: string[]
+  /** Space-delimited OAuth scopes on the token (openid/profile/…), if any. */
+  scopes: string[]
+  /** Everything else on the token, for a caller that needs a raw claim. */
+  claims: Record<string, unknown>
+}
+
+export type AuthResult =
+  | { ok: true; token: VerifiedAccessToken }
+  | { ok: false; status: 401 | 403; error: string; description: string }
+
+const DEFAULT_JWKS_TTL_MS = 600_000
+const DEFAULT_LEEWAY_S = 60
+
+type Jwk = {
+  kid?: string
+  kty: string
+  crv?: string
+  alg?: string
+  x?: string
+  y?: string
+  n?: string
+  e?: string
+}
+
+function b64urlToBytes(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4))
+  const b = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad)
+  const out = new Uint8Array(b.length)
+  for (let i = 0; i < b.length; i++) out[i] = b.charCodeAt(i)
+  return out
+}
+
+function decodeJson(segment: string): Record<string, unknown> {
+  return JSON.parse(new TextDecoder().decode(b64urlToBytes(segment)))
+}
+
+/** The WebCrypto import + verify params for the algorithms the IdP may sign with. */
+function algParams(
+  alg: string,
+  jwk: Jwk,
+): { importAlg: EcKeyImportParams | RsaHashedImportParams | Algorithm; verifyAlg: AlgorithmIdentifier | EcdsaParams | RsaPssParams } | null {
+  switch (alg) {
+    case "EdDSA":
+      return { importAlg: { name: "Ed25519" }, verifyAlg: { name: "Ed25519" } }
+    case "ES256":
+      return { importAlg: { name: "ECDSA", namedCurve: "P-256" }, verifyAlg: { name: "ECDSA", hash: "SHA-256" } }
+    case "RS256":
+      return {
+        importAlg: { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+        verifyAlg: { name: "RSASSA-PKCS1-v1_5" },
+      }
+    default:
+      return jwk.kty ? null : null
+  }
+}
+
+export function createResourceServer(options: ResourceServerOptions) {
+  const doFetch = options.fetch ?? fetch
+  const now = options.now ?? (() => Date.now())
+  const jwksUrl = options.jwksUrl ?? `${options.issuer.replace(/\/$/, "")}/jwks`
+  const jwksTtlMs = options.jwksTtlMs ?? DEFAULT_JWKS_TTL_MS
+  const leeway = (options.leewaySeconds ?? DEFAULT_LEEWAY_S) * 1000
+
+  let jwks: { at: number; keys: Jwk[] } | null = null
+
+  async function loadJwks(force: boolean): Promise<Jwk[]> {
+    if (!force && jwks && now() - jwks.at < jwksTtlMs) return jwks.keys
+    const res = await doFetch(jwksUrl)
+    if (!res.ok) throw new Error(`jwks fetch failed: ${res.status}`)
+    const body = (await res.json()) as { keys?: Jwk[] }
+    jwks = { at: now(), keys: body.keys ?? [] }
+    return jwks.keys
+  }
+
+  /** Find the signing key by kid, refetching ONCE on a miss to catch rotation. */
+  async function keyFor(kid: string | undefined): Promise<Jwk | null> {
+    const pick = (keys: Jwk[]) => keys.find((k) => (kid ? k.kid === kid : true)) ?? null
+    let key = pick(await loadJwks(false))
+    if (!key) key = pick(await loadJwks(true))
+    return key
+  }
+
+  async function verifySignature(
+    header: { alg: string; kid?: string },
+    signingInput: string,
+    signature: Uint8Array,
+  ): Promise<boolean> {
+    const jwk = await keyFor(header.kid)
+    if (!jwk) return false
+    const params = algParams(header.alg, jwk)
+    if (!params) return false
+    const key = await crypto.subtle.importKey("jwk", jwk as JsonWebKey, params.importAlg as never, false, ["verify"])
+    return crypto.subtle.verify(
+      params.verifyAlg as never,
+      key,
+      signature as unknown as BufferSource,
+      new TextEncoder().encode(signingInput) as unknown as BufferSource,
+    )
+  }
+
+  /**
+   * Verifies a raw bearer token. Returns a discriminated result rather than
+   * throwing, so the caller owns the response shape. `insufficient_scope` is a
+   * 403; everything about the token being absent or bad is a 401.
+   */
+  async function verify(token: string): Promise<AuthResult> {
+    const parts = token.split(".")
+    if (parts.length !== 3) {
+      return { ok: false, status: 401, error: "invalid_token", description: "Not a JWT." }
+    }
+    let header: { alg: string; kid?: string }
+    let claims: Record<string, unknown>
+    try {
+      header = decodeJson(parts[0]!) as { alg: string; kid?: string }
+      claims = decodeJson(parts[1]!)
+    } catch {
+      return { ok: false, status: 401, error: "invalid_token", description: "Malformed JWT." }
+    }
+
+    let valid = false
+    try {
+      valid = await verifySignature(header, `${parts[0]}.${parts[1]}`, b64urlToBytes(parts[2]!))
+    } catch {
+      valid = false
+    }
+    if (!valid) {
+      return { ok: false, status: 401, error: "invalid_token", description: "Bad signature." }
+    }
+
+    if (claims.iss !== options.issuer) {
+      return { ok: false, status: 401, error: "invalid_token", description: "Wrong issuer." }
+    }
+    const aud = claims.aud
+    const audOk = Array.isArray(aud) ? aud.includes(options.resource) : aud === options.resource
+    if (!audOk) {
+      return { ok: false, status: 401, error: "invalid_token", description: "Token is for a different resource." }
+    }
+    const t = now()
+    if (typeof claims.exp === "number" && t > claims.exp * 1000 + leeway) {
+      return { ok: false, status: 401, error: "invalid_token", description: "Token expired." }
+    }
+    if (typeof claims.nbf === "number" && t < claims.nbf * 1000 - leeway) {
+      return { ok: false, status: 401, error: "invalid_token", description: "Token not yet valid." }
+    }
+
+    const permissions = Array.isArray(claims[PERMISSIONS_CLAIM])
+      ? (claims[PERMISSIONS_CLAIM] as unknown[]).filter((p): p is string => typeof p === "string")
+      : []
+    const scopes = typeof claims.scope === "string" ? claims.scope.split(" ").filter(Boolean) : []
+    return {
+      ok: true,
+      token: {
+        sub: String(claims.sub ?? ""),
+        app: typeof claims[APP_CLAIM] === "string" ? (claims[APP_CLAIM] as string) : null,
+        permissions,
+        scopes,
+        claims,
+      },
+    }
+  }
+
+  /**
+   * The whole check off a `Request`: pull the bearer, verify it, and confirm
+   * every required permission (wildcard-aware via `grants()`). Returns a
+   * result rather than throwing.
+   */
+  async function authenticate(
+    request: { headers: { get(name: string): string | null } },
+    init: { permissions?: string[] } = {},
+  ): Promise<AuthResult> {
+    const authz = request.headers.get("authorization")
+    const bearer = authz && /^Bearer\s+(.+)$/i.exec(authz.trim())?.[1]
+    if (!bearer) {
+      return { ok: false, status: 401, error: "invalid_token", description: "No bearer token." }
+    }
+    const verified = await verify(bearer.trim())
+    if (!verified.ok) return verified
+    const missing = (init.permissions ?? []).filter((p) => !grants(verified.token.permissions, p))
+    if (missing.length) {
+      return {
+        ok: false,
+        status: 403,
+        error: "insufficient_scope",
+        description: `Missing permission(s): ${missing.join(", ")}.`,
+      }
+    }
+    return verified
+  }
+
+  /**
+   * The `WWW-Authenticate` value for a 401, pointing a client at the metadata
+   * document so it can discover how to get a token (RFC 9728 §5.1).
+   */
+  function challenge(error?: { error: string; description: string }): string {
+    const parts = [
+      `Bearer resource_metadata="${options.resource}/.well-known/oauth-protected-resource"`,
+    ]
+    if (error) parts.push(`error="${error.error}"`, `error_description="${error.description}"`)
+    return parts.join(", ")
+  }
+
+  /**
+   * The Protected Resource Metadata document (RFC 9728) — served at
+   * `/.well-known/oauth-protected-resource`. It names this resource and the
+   * IdP as its authorization server; the client takes it from there.
+   */
+  function metadata(): Record<string, unknown> {
+    return {
+      resource: options.resource,
+      authorization_servers: [options.issuer],
+      bearer_methods_supported: ["header"],
+      ...(options.scopesSupported ? { scopes_supported: options.scopesSupported } : {}),
+    }
+  }
+
+  return { verify, authenticate, challenge, metadata }
+}
+
+export type ResourceServer = ReturnType<typeof createResourceServer>

--- a/packages/idp-client/src/resource-server.ts
+++ b/packages/idp-client/src/resource-server.ts
@@ -1,0 +1,62 @@
+/**
+ * Being an OAuth 2.1 resource server against the willy.im IdP — which is what
+ * an MCP server is.
+ *
+ * The MCP authorization spec is plain OAuth with three discovery hops, and
+ * every one of them is either served by the IdP already or is a static
+ * document this module writes for you:
+ *
+ *   1. The client hits the resource without a token and gets a 401 carrying
+ *      `WWW-Authenticate: Bearer resource_metadata="…"`   → `challenge()`
+ *   2. It fetches that URL, the Protected Resource Metadata (RFC 9728), which
+ *      names the authorization server                       → `metadata()`
+ *   3. It fetches the AS metadata (RFC 8414) from the IdP, registers itself
+ *      (RFC 7591), runs authorization code + PKCE with `resource=` (RFC 8707),
+ *      and comes back with a JWT access token whose `aud` is this resource.
+ *   4. The resource server verifies that JWT against the IdP's JWKS and reads
+ *      the permissions claim                                → `verify()`
+ *
+ * Step 4 is the only one with any code in it, and it is deliberately small:
+ * signature (EdDSA, ES256 or RS256 via WebCrypto — no jose, no deps), issuer,
+ * audience, time. The permissions on the token were computed by the IdP for
+ * the app that owns this resource (the same way a browser session's are), so
+ * the app does not look anything up — it reads a claim and matches it with
+ * `grants()` like everywhere else.
+ *
+ * The JWKS is cached and refetched once on an unknown `kid`, which is how a
+ * key rotation at the IdP is picked up without a restart.
+ */
+
+import { grants } from "./claims.js"
+import { IdpError } from "./errors.js"
+
+export const PERMISSIONS_CLAIM = "https://willy.im/permissions"
+export const APP_CLAIM = "https://willy.im/app"
+
+export type ResourceServerOptions = {
+  /** The IdP's OAuth issuer — `https://idp.willy.im/auth` (note the /auth). */
+  issuer: string
+  /**
+   * This server's canonical URI, exactly as registered on the application in
+   * the IdP (`resources`) — e.g. `https://bender.romo.fyi/mcp`. It is the
+   * audience a token must carry, compared byte for byte.
+   */
+  resource: string
+  /** Defaults to `${issuer}/jwks`. */
+  jwksUrl?: string
+  /** Advertised in the metadata document. Informational only. */
+  scopesSupported?: string[]
+  /** How long a fetched JWKS is reused. Default 10 minutes. */
+  jwksTtlMs?: number
+  /** Clock skew tolerated on exp/nbf. Default 60s. */
+  leewaySeconds?: number
+  fetch?: typeof fetch
+  /** Clock seam, for tests. */
+  now?: () => number
+}
+
+/** A verified access token, reduced to what an app acts on. */
+export type VerifiedAccessToken = {
+  /** The IdP user id — the same `sub` a session or a wak_ key resolves to. */
+  sub: string
+  /** The app the permissions are for (the owner of `resource`),

--- a/packages/idp-client/src/schemas/index.ts
+++ b/packages/idp-client/src/schemas/index.ts
@@ -18,6 +18,9 @@ export const ApplicationSchema = z.object({
   app: z.string().nullable().describe("Application key; consumer workspace claims are filtered by this"),
   allowSignup: z.boolean().describe("Whether unknown users may sign themselves up"),
   permissions: z.array(z.string()).describe("The app's declared product-permission catalog"),
+  resources: z
+    .array(z.string())
+    .describe("Protected resource URIs (e.g. the app's MCP server) — valid `resource` audiences for access tokens"),
   redirectUris: z.array(z.string()),
   disabled: z.boolean(),
   createdAt: z.string().describe("ISO 8601 timestamp"),
@@ -72,6 +75,10 @@ export const UpdateApplicationInput = z.object({
   name: z.string().min(1).optional(),
   redirectUris: z.array(z.string().min(1)).min(1).optional(),
   allowSignup: z.boolean().optional(),
+  resources: z
+    .array(z.string().url())
+    .optional()
+    .describe("Replace the app's protected resource URIs — absolute https, no fragment"),
 })
 
 export const ClientSecretSchema = z.object({

--- a/packages/idp-client/test/resource-server.test.ts
+++ b/packages/idp-client/test/resource-server.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest"
+
+import { createResourceServer, PERMISSIONS_CLAIM, APP_CLAIM } from "../src/resource-server.js"
+
+/**
+ * The resource-server half: verifying a real Ed25519 JWT against a JWKS, the
+ * checks that must reject (issuer, audience, expiry, signature), and the
+ * permission gate. Keys are minted with WebCrypto so this exercises the actual
+ * verify path, not a stub.
+ */
+
+const ISSUER = "https://idp.test/auth"
+const RESOURCE = "https://bender.romo.fyi/mcp"
+
+function b64url(bytes: Uint8Array): string {
+  let s = ""
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+async function setup() {
+  const pair = (await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"])) as CryptoKeyPair
+  const jwk = (await crypto.subtle.exportKey("jwk", pair.publicKey)) as JsonWebKey
+  jwk.kid = "k1"
+  jwk.alg = "EdDSA"
+  const jwks = { keys: [jwk] }
+
+  async function mint(claims: Record<string, unknown>, opts: { kid?: string } = {}): Promise<string> {
+    const header = b64url(new TextEncoder().encode(JSON.stringify({ alg: "EdDSA", kid: opts.kid ?? "k1", typ: "JWT" })))
+    const payload = b64url(new TextEncoder().encode(JSON.stringify(claims)))
+    const input = `${header}.${payload}`
+    const sig = new Uint8Array(await crypto.subtle.sign({ name: "Ed25519" }, pair.privateKey, new TextEncoder().encode(input)))
+    return `${input}.${b64url(sig)}`
+  }
+
+  let jwksHits = 0
+  const fetchImpl = (async () => {
+    jwksHits++
+    return Response.json(jwks)
+  }) as unknown as typeof fetch
+
+  const rs = createResourceServer({ issuer: ISSUER, resource: RESOURCE, fetch: fetchImpl, now: () => 1_000_000_000_000 })
+  return { rs, mint, jwksHits: () => jwksHits }
+}
+
+const goodClaims = (over: Record<string, unknown> = {}) => ({
+  iss: ISSUER,
+  aud: RESOURCE,
+  sub: "user_willy",
+  exp: 1_000_000_000 + 3600, // now is 1e12 ms = 1e9 s; +1h
+  [APP_CLAIM]: "bender",
+  [PERMISSIONS_CLAIM]: ["chat:respond", "kirby:chats:read"],
+  scope: "openid profile",
+  ...over,
+})
+
+const req = (token?: string) => ({ headers: { get: (n: string) => (n.toLowerCase() === "authorization" && token ? `Bearer ${token}` : null) } })
+
+describe("createResourceServer.verify", () => {
+  it("accepts a well-formed token and surfaces sub, app, permissions, scopes", async () => {
+    const { rs, mint } = await setup()
+    const r = await rs.verify(await mint(goodClaims()))
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.token).toMatchObject({
+      sub: "user_willy",
+      app: "bender",
+      permissions: ["chat:respond", "kirby:chats:read"],
+      scopes: ["openid", "profile"],
+    })
+  })
+
+  it("rejects a wrong audience — a token for another resource", async () => {
+    const { rs, mint } = await setup()
+    const r = await rs.verify(await mint(goodClaims({ aud: "https://other.example/mcp" })))
+    expect(r).toMatchObject({ ok: false, status: 401 })
+  })
+
+  it("rejects a wrong issuer", async () => {
+    const { rs, mint } = await setup()
+    const r = await rs.verify(await mint(goodClaims({ iss: "https://evil.example/auth" })))
+    expect(r).toMatchObject({ ok: false, status: 401 })
+  })
+
+  it("rejects an expired token", async () => {
+    const { rs, mint } = await setup()
+    const r = await rs.verify(await mint(goodClaims({ exp: 1 })))
+    expect(r).toMatchObject({ ok: false, status: 401, description: "Token expired." })
+  })
+
+  it("rejects a tampered payload — signature no longer matches", async () => {
+    const { rs, mint } = await setup()
+    const token = await mint(goodClaims())
+    const [h, , s] = token.split(".")
+    const forged = b64url(new TextEncoder().encode(JSON.stringify(goodClaims({ [PERMISSIONS_CLAIM]: ["*"] }))))
+    const r = await rs.verify(`${h}.${forged}.${s}`)
+    expect(r).toMatchObject({ ok: false, status: 401, description: "Bad signature." })
+  })
+
+  it("rejects garbage", async () => {
+    const { rs } = await setup()
+    expect(await rs.verify("not-a-jwt")).toMatchObject({ ok: false, status: 401 })
+  })
+})
+
+describe("createResourceServer.authenticate", () => {
+  it("401 with no bearer", async () => {
+    const { rs } = await setup()
+    expect(await rs.authenticate(req())).toMatchObject({ ok: false, status: 401 })
+  })
+
+  it("passes when the required permission is held (wildcard-aware)", async () => {
+    const { rs, mint } = await setup()
+    const token = await mint(goodClaims({ [PERMISSIONS_CLAIM]: ["kirby:*"] }))
+    const r = await rs.authenticate(req(token), { permissions: ["kirby:chats:read"] })
+    expect(r.ok).toBe(true)
+  })
+
+  it("403 insufficient_scope when it is not", async () => {
+    const { rs, mint } = await setup()
+    const token = await mint(goodClaims({ [PERMISSIONS_CLAIM]: ["chat:respond"] }))
+    const r = await rs.authenticate(req(token), { permissions: ["dexter:write"] })
+    expect(r).toMatchObject({ ok: false, status: 403, error: "insufficient_scope" })
+  })
+})
+
+describe("jwks caching + rotation", () => {
+  it("caches the JWKS across verifies", async () => {
+    const { rs, mint, jwksHits } = await setup()
+    await rs.verify(await mint(goodClaims()))
+    await rs.verify(await mint(goodClaims()))
+    expect(jwksHits()).toBe(1)
+  })
+
+  it("refetches once on an unknown kid", async () => {
+    const { rs, mint, jwksHits } = await setup()
+    await rs.verify(await mint(goodClaims())) // primes cache: 1 hit
+    await rs.verify(await mint(goodClaims(), { kid: "rotated" })) // miss → 1 more
+    expect(jwksHits()).toBe(2)
+  })
+})
+
+describe("discovery documents", () => {
+  it("the WWW-Authenticate challenge points at the PRM url", async () => {
+    const { rs } = await setup()
+    expect(rs.challenge()).toContain(`resource_metadata="${RESOURCE}/.well-known/oauth-protected-resource"`)
+  })
+
+  it("the metadata names this resource and the IdP", async () => {
+    const { rs } = await setup()
+    expect(rs.metadata()).toMatchObject({ resource: RESOURCE, authorization_servers: [ISSUER] })
+  })
+})


### PR DESCRIPTION
Lets any app expose itself over MCP by registering here and nothing else.

**IdP**
- Applications gain `resources` (absolute-https URIs, e.g. `https://bender.romo.fyi/mcp`), validated as audiences.
- Dynamic client registration on (RFC 7591, anonymous public + PKCE) — Claude registers itself.
- Access tokens are **resource-scoped**: minted with `resource=<uri>` (RFC 8707), stamped with the user's permissions for the app that *owns* that resource, not the client that asked. One registered client, per-app grants.

**Package 0.5.0**
- `createResourceServer()` — verify a token against JWKS (WebCrypto, no deps), gate on permissions, plus the RFC 9728 discovery documents.
- `ApplicationSchema.resources`, `UpdateApplicationInput.resources`.

Tests: 207 idp + resource-server 13. No migration (resources live in existing metadata JSON).

After merge: `npm run db:migrate-prod` is a no-op; `npm run deploy` in apps/idp; package publishes from main.